### PR TITLE
Add frontend-specific `.prettierrc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,11 +91,6 @@
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.7.0"
   },
-  "prettier": {
-    "tabWidth": 4,
-    "singleQuote": true,
-    "useTabs": false
-  },
   "browserslist": [
     "> 1%",
     "last 2 versions",

--- a/src/.prettierrc
+++ b/src/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true,
+  "useTabs": false
+}


### PR DESCRIPTION
Since recombining the 2 repos, the former backend repo's `prettier` formatting (per `/.prettierrc`) that runs in a CI check is failing as it disagrees with the former frontend repo's formatting (per `/package.json`).

Although I would recommend we just sync them up in the near future (the only real difference is 2-space vs. 4-space indentations), this PR should provide a temporary fix for the CI check. 🤞🏻 