### PR TITLE
Tighten the version of Node that is valid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "vuetify-loader": "^1.7.0"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "16.x"
       }
     },
     "node_modules/@auth0/auth0-spa-js": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fe-dev": "npm run serve"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": "16.x"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.17.0",


### PR DESCRIPTION
Our Heroku deployments were complaining about our potentially dangerous version specification for the acceptable Node.js engines as it is allowing for experimental versions rather than only stable/LTS versions.

<img width="615" alt="image" src="https://user-images.githubusercontent.com/417751/154608647-7967a882-d3b7-473b-aaf9-c027d7505a70.png">
