### PR TITLE
Use `node-version-file` param to DRY up workflows

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: 16.x
+          node-version-file: '.node-version'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: 16.x
+          node-version-file: '.node-version'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: 16.x
+          node-version-file: '.node-version'
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
The newer versions of the `actions/setup-node` Action added an optional `node-version-file` parameter that we can use instead of the `node-version` parameter.

This allows us to point to our existing `.node-version` file to specify our desired version rather than having to maintain it separately in each workflow.

DRY it up! 🧽 