### PR TITLE
Modify postal code submit flow

### DIFF
--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -8,9 +8,14 @@
 
             <v-form ref="form">
               <v-text-field
+                :to="{
+                  name: 'Reps',
+                  params: { postalCode: postalCode }
+                }"
+                v-on:keyup="CreateRepList()"
+                v-on:keydown.enter.prevent="CreateRepList()"
                 label="Postal Code"
                 required
-                v-on:keyup="CheckInputContent"
                 v-model="postalCode"
               ></v-text-field>
             </v-form>

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -20,15 +20,6 @@
               ></v-text-field>
             </v-form>
 
-            <v-btn
-              :to="{
-                name: 'Reps',
-                params: { postalCode: postalCode }
-              }"
-              v-on:click="CreateRepList()"
-              clickclass="mr-4"
-              >Submit
-            </v-btn>
           </v-card-text>
         </v-card>
         <div id="reprenstatives-list" v-show="hasContent">


### PR DESCRIPTION
Problem:
- Clicking "enter" after you typed in your zip code just refreshed the page

Solution: 
- Tried to get enter to not refresh the page but that did not work. Instead, disabled enter from doing anything.
- If valid zip is entered, the results will appear on the screen automatically (no enter or submit button push)
- Remove submit button on postal code screen

https://user-images.githubusercontent.com/19912012/159782076-38d47023-5f44-4cf7-8aa2-1c029b2ed790.mov


