### PR TITLE
Added campaign orm model. Modified API

### DIFF
--- a/server/db/models/campaign.js
+++ b/server/db/models/campaign.js
@@ -1,0 +1,29 @@
+const Model = require('./_base')
+
+class Campaign extends Model {
+  static get tableName() {
+    return 'campaigns'
+  }
+
+  // Optional JSON schema. This is not the database schema! Nothing is generated
+  // based on this. This is only used for validation. Whenever a model instance
+  // is created it is checked against this schema. http://json-schema.org/.
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['name'],
+
+      properties: {
+        id: { type: 'integer' },
+        organization: { type: 'string', minLength: 1, maxLength: 255 },
+        name: { type: 'string', minLength: 1, maxLength: 255 },
+        cause: { type: 'string', minLength: 1, maxLength: 255 },
+        type: { type: 'string', minLength: 1, maxLength: 255 },
+        page_url: { type: 'string', minLength: 1, maxLength: 255 },
+        letters_counter: { type: 'integer' }
+      }
+    }
+  }
+}
+
+module.exports = Campaign

--- a/server/routes/api/campaigns.js
+++ b/server/routes/api/campaigns.js
@@ -1,12 +1,12 @@
 const express = require('express')
-const { createClient } = require('../../db')
 const router = express.Router()
-const db = createClient()
+const Campaign = require('../../db/models/campaign')
 
 router.get('/:id', async (req, res) => {
   const id = req.params.id
   try {
-    const result = await db('campaigns').where('id', id)
+    const result = await Campaign.query().select('*').where('id', '=', id)
+    console.log(result)
     res.send(result)
   } catch (error) {
     console.log(error)
@@ -16,7 +16,7 @@ router.get('/:id', async (req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const result = await db.select('*').from('campaigns')
+    const result = await Campaign.query()
     console.log(result)
     res.send(result)
   } catch (error) {


### PR DESCRIPTION
This PR adds an ORM for the `campaigns' table.  Issue #141 

I created a new object model for `campaigns`, then modified the `campaigns` api to use this object model.  I did not see where the campaign table had any relations to other tables, so I did not create any relations in the ORM.