### PR TITLE
Add migration to rename 'volunteers' table to 'constituents'

### DIFF
--- a/server/db/migrations/20210729063333_create-variants-table.js
+++ b/server/db/migrations/20210729063333_create-variants-table.js
@@ -16,6 +16,6 @@ module.exports = {
   },
 
   async down(knex) {
-    await knex.schema.dropTable()
+    await knex.schema.dropTable(tableName)
   }
 }

--- a/server/db/migrations/20220413154827_rename-volunteers-table-to-constituents.js
+++ b/server/db/migrations/20220413154827_rename-volunteers-table-to-constituents.js
@@ -1,0 +1,41 @@
+const referencingTableName = 'sent_letters'
+const oldTableName = 'volunteers'
+const newTableName = 'constituents'
+
+module.exports = {
+  async up(knex) {
+    // Step 1: Unbind the referencing table
+    await knex.schema.table(referencingTableName, (table) => {
+      table.dropIndex(['volunteer_id'])
+      table.dropForeign('volunteer_id')
+    })
+
+    // Step 2: Rename the primary table
+    await knex.schema.renameTable(oldTableName, newTableName)
+
+    // Step 3: Rebind the referencing table
+    await knex.schema.table(referencingTableName, (table) => {
+      table.renameColumn('volunteer_id', 'constituent_id')
+      table.foreign('constituent_id').references(`${newTableName}.id`)
+      table.index(['constituent_id'])
+    })
+  },
+
+  async down(knex) {
+    // Step 1: Unbind the referencing table
+    await knex.schema.table(referencingTableName, (table) => {
+      table.dropIndex(['constituent_id'])
+      table.dropForeign('constituent_id')
+    })
+
+    // Step 2: Rename the primary table
+    await knex.schema.renameTable(newTableName, oldTableName)
+
+    // Step 3: Rebind the referencing table
+    await knex.schema.table(referencingTableName, (table) => {
+      table.renameColumn('constituent_id', 'volunteer_id')
+      table.foreign('volunteer_id').references(`${oldTableName}.id`)
+      table.index(['volunteer_id'])
+    })
+  }
+}


### PR DESCRIPTION
As discussed at a ProgramEquity pairing meeting, renaming the [currently unused] `volunteers` table to `constituents` probably makes more sense. 👍🏻 

TODO after merging:
- [ ] May need to update https://github.com/ProgramEquity/amplify/wiki/Data-Structures#letter-sent-table
- [ ] May need to update https://github.com/ProgramEquity/amplify/wiki/Data-Structures#constituent-table
- [ ] May need to remove https://github.com/ProgramEquity/amplify/wiki/Data-Structures#volunteer-user-table