### PR TITLE
Add Actions workflow to build project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build application
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.repository == 'ProgramEquity/amplify' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Setup node
+        uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Build application
         run: npm run build
+        env:
+          # Auth0 authentication parameters with nonsensical sample values
+          SERVER_PORT: 8080
+          CLIENT_ORIGIN_URL: http://localhost:8080
+          AUTH0_AUDIENCE: your_Auth0_identifier_value
+          AUTH0_DOMAIN: your_Auth0_domain


### PR DESCRIPTION
This will hopefully prevent us from accidentally merging Dependabot PRs that break the Vue build (e.g. https://github.com/ProgramEquity/amplify/pull/136) as this workflow would have failed in CI. 🤞🏻 