### PR TITLE
Remove `campaigns` table's `letters_counter` column

### DIFF
--- a/server/db/migrations/20220425034702_remove-campaigns-letters_counter.js
+++ b/server/db/migrations/20220425034702_remove-campaigns-letters_counter.js
@@ -1,0 +1,19 @@
+const tableName = 'campaigns'
+
+module.exports = {
+  async up(knex) {
+    // Alter the table
+    await knex.schema.alterTable(tableName, function (table) {
+      // Drop columns
+      table.dropColumn('letters_counter')
+    })
+  },
+
+  async down(knex) {
+    // Alter the table
+    await knex.schema.alterTable(tableName, function (table) {
+      // Add columns
+      table.integer('letters_counter').notNullable()
+    })
+  }
+}

--- a/server/db/models/campaign.js
+++ b/server/db/models/campaign.js
@@ -24,8 +24,6 @@ class Campaign extends BaseModel {
         type: { type: 'string', enum: ['Starter', 'Accelerator', 'Grant'] },
         page_url: { type: 'string', minLength: 1 },
         logo_url: { type: 'string', minLength: 1 },
-        // TODO: Move `letters_counter` to be a mapped relation
-        letters_counter: { type: 'integer', minimum: 0 },
         letters_goal: {
           anyOf: [{ type: 'integer', minimum: 0 }, { type: 'null' }]
         },

--- a/server/db/seeds/development/seed-campaigns-table.js
+++ b/server/db/seeds/development/seed-campaigns-table.js
@@ -12,8 +12,7 @@ module.exports = {
         name: 'The Breathe Act',
         cause: 'Civic Rights',
         type: 'Grant',
-        page_url: 'breatheact.org',
-        letters_counter: 0
+        page_url: 'breatheact.org'
       },
       {
         id: 2,
@@ -21,8 +20,7 @@ module.exports = {
         name: 'Climate and Community Investment Act',
         cause: 'Climate Justice',
         type: 'Grant',
-        page_url: 'climatecantwait.org',
-        letters_counter: 0
+        page_url: 'climatecantwait.org'
       },
       {
         id: 3,
@@ -30,8 +28,7 @@ module.exports = {
         name: 'Energy Efficiency, Equity and Jobs Assembly Bill',
         cause: 'Climate Justice',
         type: 'Grant',
-        page_url: 'climatecantwait.org',
-        letters_counter: 0
+        page_url: 'climatecantwait.org'
       },
       {
         id: 4,
@@ -39,8 +36,7 @@ module.exports = {
         name: 'Proposed Actions on EJ Communities',
         cause: 'Climate Justice',
         type: 'Grant',
-        page_url: 'climatecantwait.org',
-        letters_counter: 0
+        page_url: 'climatecantwait.org'
       }
     ])
   }


### PR DESCRIPTION
Remove `campaigns` table's `letters_counter` column

💡 The correct way to achieve this with a relational database like PostgreSQL is to add a model method to calculate this based on the relationship between `campaigns`/`letter_versions` ↔️  `sent_letters` (which is not currently populated). This can be re-implemented in the future when we are actually saving data to the `sent_letters` table.