### PR TITLE
Remove unused devDep 'concurrently'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@vue/cli-plugin-router": "~4.5.0",
         "@vue/cli-plugin-vuex": "~4.5.0",
         "@vue/cli-service": "~4.5.0",
-        "concurrently": "^7.0.0",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-vue": "^8.7.1",
@@ -6206,49 +6205,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/concurrently": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
-        "tree-kill": "^1.2.2",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
-      }
-    },
-    "node_modules/concurrently/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/configstore": {
@@ -15405,17 +15361,6 @@
         "aproba": "^1.1.1"
       }
     },
-    "node_modules/rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -16126,11 +16071,6 @@
     },
     "node_modules/source-map-url": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/spawn-command": {
-      "version": "0.0.2-1",
       "dev": true,
       "license": "MIT"
     },
@@ -17345,14 +17285,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "dev": true,
@@ -17370,11 +17302,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -24423,33 +24350,6 @@
         }
       }
     },
-    "concurrently": {
-      "version": "7.0.0",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
-        "tree-kill": "^1.2.2",
-        "yargs": "^16.2.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "configstore": {
       "version": "5.0.1",
       "dev": true,
@@ -30946,13 +30846,6 @@
         "aproba": "^1.1.1"
       }
     },
-    "rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1"
     },
@@ -31462,10 +31355,6 @@
     },
     "source-map-url": {
       "version": "0.4.1",
-      "dev": true
-    },
-    "spawn-command": {
-      "version": "0.0.2-1",
       "dev": true
     },
     "spdx-correct": {
@@ -32355,20 +32244,12 @@
         "punycode": "^2.1.1"
       }
     },
-    "tree-kill": {
-      "version": "1.2.2",
-      "dev": true
-    },
     "tryer": {
       "version": "1.0.1",
       "dev": true
     },
     "ts-pnp": {
       "version": "1.2.0",
-      "dev": true
-    },
-    "tslib": {
-      "version": "1.14.1",
       "dev": true
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-plugin-vuex": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
-    "concurrently": "^7.0.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-vue": "^8.7.1",


### PR DESCRIPTION
We used this temporarily before we got Express and Vue cooperating together but its usage was removed a while back ([by me](https://github.com/ProgramEquity/amplify/commit/b06c622a447ca807a092d2fea174bc9bbb1569a3) 😅). 