### PR TITLE
Remove unused devDep 'nodemon'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "jest": "^27.5.1",
         "less": "^4.1.2",
         "less-loader": "^5.0.0",
-        "nodemon": "^2.0.7",
         "prettier": "2.6.2",
         "sass": "^1.51.0",
         "sass-loader": "^12.6.0",
@@ -2286,14 +2285,6 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2399,17 +2390,6 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.29.0.tgz",
       "integrity": "sha512-OsUxk0VLlum8E2d6onlEdKuQcvLMs7qTrOXCnl/BGV3fAm65qr6h3e1IZ5AX4lgUlPRrzRcddSOA5DvkKKYLvg=="
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -4186,11 +4166,6 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
       "license": "MIT"
@@ -4298,14 +4273,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -5065,38 +5032,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/boxen": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/camelcase": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -5385,45 +5320,6 @@
         "webpack": "^4.0.0"
       }
     },
-    "node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "license": "MIT",
@@ -5654,11 +5550,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/ci-info": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "dev": true,
@@ -5773,17 +5664,6 @@
       },
       "engines": {
         "node": ">= 4.0"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -5963,14 +5843,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
       }
     },
     "node_modules/co": {
@@ -6205,22 +6077,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/connect-history-api-fallback": {
@@ -6672,14 +6528,6 @@
         "node": "*"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/css-color-names": {
       "version": "0.0.4",
       "dev": true,
@@ -7028,17 +6876,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -7059,14 +6896,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -7159,11 +6988,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
@@ -7491,11 +7315,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "dev": true,
@@ -7786,14 +7605,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-goat": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/escape-html": {
@@ -9247,20 +9058,6 @@
       "dev": true,
       "license": "BSD"
     },
-    "node_modules/global-dirs": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -9300,27 +9097,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/got": {
-      "version": "9.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/graceful-fs": {
@@ -9471,14 +9247,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-yarn": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hash-base": {
@@ -9739,11 +9507,6 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "dev": true,
@@ -9934,11 +9697,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/image-size": {
       "version": "0.5.5",
       "dev": true,
@@ -10011,14 +9769,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-lazy": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -10068,14 +9818,6 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/internal-ip": {
       "version": "4.3.0",
@@ -10330,17 +10072,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-ci": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^2.0.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
     "node_modules/is-color-stop": {
       "version": "1.1.0",
       "dev": true,
@@ -10471,21 +10202,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-installed-globally": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -10504,17 +10220,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-npm": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -10575,14 +10280,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -10739,11 +10436,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-yarn-global": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -11673,11 +11365,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true,
@@ -11821,14 +11508,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keyv": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "node_modules/killable": {
       "version": "1.0.1",
       "dev": true,
@@ -11906,17 +11585,6 @@
         "tedious": {
           "optional": true
         }
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "package-json": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/launch-editor": {
@@ -12242,14 +11910,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "dev": true,
@@ -12485,14 +12145,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -12897,61 +12549,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nodemon": {
-      "version": "2.0.15",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5",
-        "update-notifier": "^5.1.0"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -12985,14 +12582,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "4.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm-run-path": {
@@ -13434,14 +13023,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "dev": true,
@@ -13500,28 +13081,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/packet-reader": {
@@ -14552,14 +14111,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prepend-http": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
@@ -14681,11 +14232,6 @@
       "version": "1.8.0",
       "license": "MIT"
     },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "dev": true,
@@ -14737,17 +14283,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pupa": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-goat": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/q": {
@@ -14840,33 +14375,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/ini": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -15037,28 +14545,6 @@
     "node_modules/register-service-worker": {
       "version": "1.7.2",
       "license": "MIT"
-    },
-    "node_modules/registry-auth-token": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/regjsgen": {
       "version": "0.6.0",
@@ -15263,14 +14749,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^1.0.0"
       }
     },
     "node_modules/restore-cursor": {
@@ -15506,25 +14984,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/send": {
@@ -17205,14 +16664,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/to-regex": {
       "version": "3.0.2",
       "dev": true,
@@ -17250,17 +16701,6 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -17412,11 +16852,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/unfetch": {
       "version": "4.2.0",
       "license": "MIT"
@@ -17509,17 +16944,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "dev": true,
@@ -17594,33 +17018,6 @@
         "yarn": "*"
       }
     },
-    "node_modules/update-notifier": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boxen": "^5.0.0",
-        "chalk": "^4.1.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.4.0",
-        "is-npm": "^5.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.1.0",
-        "pupa": "^2.1.1",
-        "semver": "^7.3.4",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
-      }
-    },
     "node_modules/upper-case": {
       "version": "1.1.3",
       "dev": true,
@@ -17688,17 +17085,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/url/node_modules/punycode": {
@@ -19459,17 +18845,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "dev": true,
@@ -19752,14 +19127,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -21389,10 +20756,6 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -21468,13 +20831,6 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.29.0.tgz",
       "integrity": "sha512-OsUxk0VLlum8E2d6onlEdKuQcvLMs7qTrOXCnl/BGV3fAm65qr6h3e1IZ5AX4lgUlPRrzRcddSOA5DvkKKYLvg=="
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -22895,10 +22251,6 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "dev": true
-    },
     "abortcontroller-polyfill": {
       "version": "1.7.3"
     },
@@ -22969,13 +22321,6 @@
     "alphanum-sort": {
       "version": "1.0.2",
       "dev": true
-    },
-    "ansi-align": {
-      "version": "3.0.1",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.1.0"
-      }
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -23527,26 +22872,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "boxen": {
-      "version": "5.1.2",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.2.1",
-          "dev": true
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -23778,32 +23103,6 @@
         "schema-utils": "^2.0.0"
       }
     },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "dev": true,
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "dev": true
-        }
-      }
-    },
     "call-bind": {
       "version": "1.0.2",
       "requires": {
@@ -23953,10 +23252,6 @@
       "version": "1.0.3",
       "dev": true
     },
-    "ci-info": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "cipher-base": {
       "version": "1.0.4",
       "dev": true,
@@ -24041,10 +23336,6 @@
       "requires": {
         "source-map": "~0.6.0"
       }
-    },
-    "cli-boxes": {
-      "version": "2.2.1",
-      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -24162,13 +23453,6 @@
     "clone": {
       "version": "2.1.2",
       "dev": true
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -24348,18 +23632,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "configstore": {
-      "version": "5.0.1",
-      "dev": true,
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -24691,10 +23963,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "css-color-names": {
       "version": "0.0.4",
       "dev": true
@@ -24932,13 +24200,6 @@
       "version": "0.2.0",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -24956,10 +24217,6 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -25023,10 +24280,6 @@
           "dev": true
         }
       }
-    },
-    "defer-to-connect": {
-      "version": "1.1.3",
-      "dev": true
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -25259,10 +24512,6 @@
       "version": "0.1.2",
       "dev": true
     },
-    "duplexer3": {
-      "version": "0.1.4",
-      "dev": true
-    },
     "duplexify": {
       "version": "3.7.1",
       "dev": true,
@@ -25488,10 +24737,6 @@
     },
     "escalade": {
       "version": "3.1.1"
-    },
-    "escape-goat": {
-      "version": "2.1.1",
-      "dev": true
     },
     "escape-html": {
       "version": "1.0.3"
@@ -26533,13 +25778,6 @@
       "version": "0.3.0",
       "dev": true
     },
-    "global-dirs": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "ini": "2.0.0"
-      }
-    },
     "globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -26567,23 +25805,6 @@
           "version": "2.0.0",
           "dev": true
         }
-      }
-    },
-    "got": {
-      "version": "9.6.0",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -26681,10 +25902,6 @@
           }
         }
       }
-    },
-    "has-yarn": {
-      "version": "2.1.0",
-      "dev": true
     },
     "hash-base": {
       "version": "3.1.0",
@@ -26877,10 +26094,6 @@
         "entities": "^2.0.0"
       }
     },
-    "http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true
-    },
     "http-deceiver": {
       "version": "1.2.7",
       "dev": true
@@ -27001,10 +26214,6 @@
       "version": "4.0.6",
       "dev": true
     },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "image-size": {
       "version": "0.5.5",
       "dev": true,
@@ -27052,10 +26261,6 @@
         }
       }
     },
-    "import-lazy": {
-      "version": "2.1.0",
-      "dev": true
-    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -27088,10 +26293,6 @@
     },
     "inherits": {
       "version": "2.0.4"
-    },
-    "ini": {
-      "version": "2.0.0",
-      "dev": true
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -27248,13 +26449,6 @@
       "version": "1.2.4",
       "dev": true
     },
-    "is-ci": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
     "is-color-stop": {
       "version": "1.1.0",
       "dev": true,
@@ -27332,14 +26526,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-installed-globally": {
-      "version": "0.4.0",
-      "dev": true,
-      "requires": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      }
-    },
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -27348,10 +26534,6 @@
     },
     "is-negative-zero": {
       "version": "2.0.2",
-      "dev": true
-    },
-    "is-npm": {
-      "version": "5.0.0",
       "dev": true
     },
     "is-number": {
@@ -27388,10 +26570,6 @@
           }
         }
       }
-    },
-    "is-path-inside": {
-      "version": "3.0.3",
-      "dev": true
     },
     "is-plain-obj": {
       "version": "3.0.0",
@@ -27480,10 +26658,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "is-yarn-global": {
-      "version": "0.3.0",
-      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -28206,10 +27380,6 @@
       "version": "2.5.2",
       "dev": true
     },
-    "json-buffer": {
-      "version": "3.0.0",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true
@@ -28318,13 +27488,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "keyv": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "dev": true
@@ -28361,13 +27524,6 @@
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
         "tildify": "2.0.0"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "package-json": "^6.3.0"
       }
     },
     "launch-editor": {
@@ -28610,10 +27766,6 @@
       "version": "1.1.4",
       "dev": true
     },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "lru-cache": {
       "version": "6.0.0",
       "dev": true,
@@ -28785,10 +27937,6 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
       "dev": true
     },
     "mini-css-extract-plugin": {
@@ -29112,42 +28260,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "nodemon": {
-      "version": "2.0.15",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5",
-        "update-notifier": "^5.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "dev": true
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -29170,10 +28282,6 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "dev": true
-    },
-    "normalize-url": {
-      "version": "4.5.1",
       "dev": true
     },
     "npm-run-path": {
@@ -29466,10 +28574,6 @@
       "version": "0.3.0",
       "dev": true
     },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "dev": true
@@ -29502,22 +28606,6 @@
     "p-try": {
       "version": "2.2.0",
       "dev": true
-    },
-    "package-json": {
-      "version": "6.5.0",
-      "dev": true,
-      "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
     },
     "packet-reader": {
       "version": "1.0.0"
@@ -30275,10 +29363,6 @@
       "version": "1.2.1",
       "dev": true
     },
-    "prepend-http": {
-      "version": "2.0.0",
-      "dev": true
-    },
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
@@ -30360,10 +29444,6 @@
     "psl": {
       "version": "1.8.0"
     },
-    "pstree.remy": {
-      "version": "1.1.8",
-      "dev": true
-    },
     "public-encrypt": {
       "version": "4.0.3",
       "dev": true,
@@ -30411,13 +29491,6 @@
     },
     "punycode": {
       "version": "2.1.1"
-    },
-    "pupa": {
-      "version": "2.1.1",
-      "dev": true,
-      "requires": {
-        "escape-goat": "^2.0.0"
-      }
     },
     "q": {
       "version": "1.5.1",
@@ -30478,26 +29551,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "1.3.8",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "dev": true
-        }
       }
     },
     "react-is": {
@@ -30618,20 +29671,6 @@
     },
     "register-service-worker": {
       "version": "1.7.2"
-    },
-    "registry-auth-token": {
-      "version": "4.2.1",
-      "dev": true,
-      "requires": {
-        "rc": "^1.2.8"
-      }
-    },
-    "registry-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "rc": "^1.2.8"
-      }
     },
     "regjsgen": {
       "version": "0.6.0",
@@ -30780,13 +29819,6 @@
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
-    "responselike": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
     "restore-cursor": {
       "version": "2.0.0",
       "dev": true,
@@ -30920,19 +29952,6 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
-      }
-    },
-    "semver-diff": {
-      "version": "3.1.1",
-      "dev": true,
-      "requires": {
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
       }
     },
     "send": {
@@ -32191,10 +31210,6 @@
         }
       }
     },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "to-regex": {
       "version": "3.0.2",
       "dev": true,
@@ -32220,13 +31235,6 @@
     "toposort": {
       "version": "1.0.7",
       "dev": true
-    },
-    "touch": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "nopt": "~1.0.10"
-      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -32326,10 +31334,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "undefsafe": {
-      "version": "2.0.5",
-      "dev": true
-    },
     "unfetch": {
       "version": "4.2.0"
     },
@@ -32399,13 +31403,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "unique-string": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
-    },
     "universalify": {
       "version": "0.1.2",
       "dev": true
@@ -32454,26 +31451,6 @@
     "upath": {
       "version": "1.2.0",
       "dev": true
-    },
-    "update-notifier": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "boxen": "^5.0.0",
-        "chalk": "^4.1.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.4.0",
-        "is-npm": "^5.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.1.0",
-        "pupa": "^2.1.1",
-        "semver": "^7.3.4",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -32526,13 +31503,6 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0"
       }
     },
     "use": {
@@ -33806,13 +32776,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "widest-line": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.0.0"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "dev": true
@@ -34051,10 +33014,6 @@
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true,
       "requires": {}
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "jest": "^27.5.1",
     "less": "^4.1.2",
     "less-loader": "^5.0.0",
-    "nodemon": "^2.0.7",
     "prettier": "2.6.2",
     "sass": "^1.51.0",
     "sass-loader": "^12.6.0",


### PR DESCRIPTION
Closes #206 

We used this before we got Express and Vue cooperating together but its usage was removed a while back ([by me](https://github.com/ProgramEquity/amplify/commit/b06c622a447ca807a092d2fea174bc9bbb1569a3) 😅). 