### PR TITLE
Awkward word wrapping fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21465,8 +21465,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -21803,8 +21802,7 @@
     },
     "@vue/cli-plugin-vuex": {
       "version": "4.5.15",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/cli-service": {
       "version": "4.5.15",
@@ -22054,8 +22052,7 @@
     },
     "@vue/preload-webpack-plugin": {
       "version": "1.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/web-component-wrapper": {
       "version": "1.3.0",
@@ -22267,8 +22264,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -22298,13 +22294,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -24857,8 +24851,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-vue": {
       "version": "8.7.1",
@@ -25188,8 +25181,7 @@
     "express-rate-limit": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.4.0.tgz",
-      "integrity": "sha512-lxQRZI4gi3qAWTf0/Uqsyugsz57h8bd7QyllXBgJvd6DJKokzW7C5DTaNvwzvAQzwHGFaItybfYGhC8gpu0V2A==",
-      "requires": {}
+      "integrity": "sha512-lxQRZI4gi3qAWTf0/Uqsyugsz57h8bd7QyllXBgJvd6DJKokzW7C5DTaNvwzvAQzwHGFaItybfYGhC8gpu0V2A=="
     },
     "express-unless": {
       "version": "1.0.0"
@@ -27030,8 +27022,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -28775,8 +28766,7 @@
     "pg-pool": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
-      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
-      "requires": {}
+      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ=="
     },
     "pg-protocol": {
       "version": "1.5.0"
@@ -31680,8 +31670,7 @@
     "vuetify": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.4.tgz",
-      "integrity": "sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w==",
-      "requires": {}
+      "integrity": "sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w=="
     },
     "vuetify-loader": {
       "version": "1.7.3",
@@ -31721,8 +31710,7 @@
       }
     },
     "vuex": {
-      "version": "3.6.2",
-      "requires": {}
+      "version": "3.6.2"
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -32999,8 +32987,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/src/components/CampaignCards.vue
+++ b/src/components/CampaignCards.vue
@@ -9,8 +9,7 @@
             height="200px"
           ></v-img>
 
-          <v-card-title style="word-break: break-word" v-text="campaign.name">
-          </v-card-title>
+          <h5 v-text="campaign.name" class="text-h5"></h5>
 
           <v-card-subtitle
             v-text="campaign.organization"

--- a/src/components/CampaignCards.vue
+++ b/src/components/CampaignCards.vue
@@ -10,7 +10,7 @@
           ></v-img>
 
           <v-card-title 
-            stygitle="word-break: break-word"  
+            style="word-break: break-word"  
             v-text="campaign.name"
           >
           </v-card-title>

--- a/src/components/CampaignCards.vue
+++ b/src/components/CampaignCards.vue
@@ -9,7 +9,11 @@
             height="200px"
           ></v-img>
 
-          <v-card-title v-text="campaign.name"></v-card-title>
+          <v-card-title 
+            stygitle="word-break: break-word"  
+            v-text="campaign.name"
+          >
+          </v-card-title>
 
           <v-card-subtitle
             v-text="campaign.organization"

--- a/src/components/CampaignCards.vue
+++ b/src/components/CampaignCards.vue
@@ -9,10 +9,7 @@
             height="200px"
           ></v-img>
 
-          <v-card-title 
-            style="word-break: break-word"  
-            v-text="campaign.name"
-          >
+          <v-card-title style="word-break: break-word" v-text="campaign.name">
           </v-card-title>
 
           <v-card-subtitle


### PR DESCRIPTION
Problem:

Some of the newer campaigns we've added for Sunrise have longer names. Some of these are exhibiting some awkward word-wrapping, e.g:

<img width="354" alt="159747842-dd297e80-838c-47a6-833c-ae7e5f585cef" src="https://user-images.githubusercontent.com/72050998/173651567-a4c6379c-b20a-4cb5-8a96-ba4cc0600819.png">


Solution:

Add word-break styling to campaign title 