### PR TITLE
Re-enable CORS support but ONLY for developers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^0.27.2",
         "cli-plugin-eslint": "^0.1.0",
         "connect-history-api-fallback": "^1.6.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.1",
         "express-jwt": "^6.1.1",
@@ -6419,6 +6420,18 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "5.2.1",
       "dev": true,
@@ -12614,7 +12627,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23864,6 +23876,15 @@
     "core-util-is": {
       "version": "1.0.2"
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "5.2.1",
       "dev": true,
@@ -28299,8 +28320,7 @@
       "version": "0.9.0"
     },
     "object-assign": {
-      "version": "4.1.1",
-      "dev": true
+      "version": "4.1.1"
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "axios": "^0.27.2",
     "cli-plugin-eslint": "^0.1.0",
     "connect-history-api-fallback": "^1.6.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.18.1",
     "express-jwt": "^6.1.1",

--- a/server/api.js
+++ b/server/api.js
@@ -2,6 +2,7 @@
 require('dotenv').config()
 
 const express = require('express')
+const cors = require('cors')
 const rateLimit = require('express-rate-limit')
 
 const representatives = require('./routes/api/representatives')
@@ -17,6 +18,12 @@ const apiRouter = express.Router()
 
 // Middleware
 apiRouter.use(express.json())
+
+// Allow CORS support but only for development scenarios (e.g. to enable Postman testing)
+const { NODE_ENV } = process.env
+if (!NODE_ENV || NODE_ENV === 'development') {
+  apiRouter.use(cors())
+}
 
 // Rate Limiting
 const apiLimiter = rateLimit({


### PR DESCRIPTION
Allow CORS support but only for development scenarios (e.g. to enable Postman testing)

Mostly reverts commit 662d763139e37820cc317b357f9a27ffedbec206