### PR TITLE
Bug: Backend Stripe Verification

### DIFF
--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -158,9 +158,13 @@ router.post('/createLetter', async (req, res) => {
     )
 
     if (paymentVerification.status !== 'succeeded') {
+      const { status } = paymentVerification
       return res
         .status(500)
-        .json({ msg: 'Payment is still pending or has failed.' })
+        .json({
+          msg: 'Payment is still pending or has failed.',
+          status
+        })
         .end()
     }
 

--- a/src/components/ActionComplete.vue
+++ b/src/components/ActionComplete.vue
@@ -27,7 +27,6 @@ export default {
     },
     methods: {
         getSession() {
-            axios.defaults.baseURL = '//localhost:6000/';
             const session_id = {'session_id': this.$route.query.session_id }
             axios.post( '/api/checkout/create-transaction', session_id )
                 .then((response) => {


### PR DESCRIPTION
Resolves #213. Few points to be noted:

1. I am unable to make sense of this setting, nor was keeping it letting the success page show the e-mail address and donated amount correctly. It was showing an error in the browser console too, due to which I removed it.

   `src/components/ActionComplete.vue#30`
   ```js
   methods: {
       getSession() {
           axios.defaults.baseURL = '//localhost:6000/';
           //                       ^^^^^^^^^^^^^^^^^^^^
           const session_id = {'session_id': this.$route.query.session_id }
           axios.post( '/api/checkout/create-transaction', session_id )
               .then((response) => {
                   this.data  = response.data
               })
               .catch(function (error) {
                   console.log(error)
               })
         },
   }
   ```

2. I can't find anywhere in the front-end where `/createLetter` is being `POST`ed (except for the test case in `server/__tests__/integration/lob.test.js`). Does that mean the letter-sending end-point is not being called yet? 

   I modified it to return the failure status code (as received from Stripe) so that it can be dealt with in the front-end, when we implement the part where it is being called.

3. A failed payment may never lead us to the success page or the back-end, because the Stripe window won't let me proceed _until_ the payment finally succeeds. This conclusion comes by testing the [failing test cards](https://stripe.com/docs/testing#declined-payments) as discussed in last week's pair hours.

I think this PR needs review and further discussion.