### PR TITLE
Filtering by Jurisdiction: Federal, State, County

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5408,13 +5408,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001296",
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
       "dev": true,
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -23153,7 +23160,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001296",
+      "version": "1.0.30001361",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
+      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -43,8 +43,7 @@ router.get('/:zipCode', async (req, res) => {
 
     const { offices, officials } = response.data
     offices
-      .slice(0)
-      // .slice(2) // skip President and VP
+      .slice(2) // skip President and VP
       .forEach((officeType) => {
         officeType.officialIndices.forEach((position) => {
           const rep = officials[position]

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -42,52 +42,61 @@ router.get('/:zipCode', async (req, res) => {
     console.log(response)
 
     const { offices, officials } = response.data
-    offices
-      .slice(2) // skip President and VP
-      .forEach((officeType) => {
-        officeType.officialIndices.forEach((position) => {
-          const rep = officials[position]
-          const repInfo = {
-            name: rep.name || '',
-            title: officeType.name || '',
-            address_line1: '',
-            address_line2: '',
-            address_city: '',
-            address_state: '',
-            address_zip: '',
-            address_country: 'US',
-            email:
-              (Array.isArray(rep.emails) && rep.emails[0]) || 'Not Made Public',
-            twitter: 'Not Made Public',
-            facebook: 'Not Made Public',
-            contactPage: (Array.isArray(rep.urls) && rep.urls[0]) || '',
-            photoUrl:
-              rep.photoUrl ||
-              'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png'
-          }
 
-          if (Array.isArray(rep.address) && rep.address[0]) {
-            repInfo.address_line1 = rep.address[0].line1
-            repInfo.address_city = rep.address[0].city
-            repInfo.address_state = rep.address[0].state
-            repInfo.address_zip = rep.address[0].zip
-          }
+    const getOfficials = (officeType) => {
+      officeType.officialIndices.forEach((position) => {
+        const rep = officials[position]
+        const repInfo = {
+          name: rep.name || '',
+          title: officeType.name || '',
+          address_line1: '',
+          address_line2: '',
+          address_city: '',
+          address_state: '',
+          address_zip: '',
+          address_country: 'US',
+          email:
+            (Array.isArray(rep.emails) && rep.emails[0]) || 'Not Made Public',
+          twitter: 'Not Made Public',
+          facebook: 'Not Made Public',
+          contactPage: (Array.isArray(rep.urls) && rep.urls[0]) || '',
+          photoUrl:
+            rep.photoUrl ||
+            'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png'
+        }
 
-          if (Array.isArray(rep.channels) && rep.channels.length > 0) {
-            const facebook = rep.channels.find(
-              ({ type }) => type === 'Facebook'
-            )
-            if (facebook) {
-              repInfo.facebook = facebook.id
-            }
-            const twitter = rep.channels.find(({ type }) => type === 'Twitter')
-            if (twitter) {
-              repInfo.twitter = twitter.id
-            }
+        if (Array.isArray(rep.address) && rep.address[0]) {
+          repInfo.address_line1 = rep.address[0].line1
+          repInfo.address_city = rep.address[0].city
+          repInfo.address_state = rep.address[0].state
+          repInfo.address_zip = rep.address[0].zip
+        }
+
+        if (Array.isArray(rep.channels) && rep.channels.length > 0) {
+          const facebook = rep.channels.find(({ type }) => type === 'Facebook')
+          if (facebook) {
+            repInfo.facebook = facebook.id
           }
-          congressMembers.push(repInfo)
-        })
+          const twitter = rep.channels.find(({ type }) => type === 'Twitter')
+          if (twitter) {
+            repInfo.twitter = twitter.id
+          }
+        }
+        congressMembers.push(repInfo)
       })
+    }
+
+    if (
+      filter === 'administrativeArea1' ||
+      filter === 'administrativeArea2' ||
+      filter === 'locality'
+    ) {
+      offices.slice(0).forEach((officeType) => getOfficials(officeType))
+    } else {
+      offices
+        .slice(2) // skip President and VP
+        .forEach((officeType) => getOfficials(officeType))
+    }
 
     res.send(congressMembers)
   } catch (error) {

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -13,6 +13,7 @@ const CIVIC_API_KEY = getCivicApiKey()
 router.get('/:zipCode', async (req, res) => {
   const congressMembers = []
   const { zipCode } = req.params
+  const { filter } = req.query
 
   if (!zipCode.match(/^\d{5}(-\d{4})?$/)) {
     res.status(400).send({
@@ -23,15 +24,22 @@ router.get('/:zipCode', async (req, res) => {
     return
   }
   try {
+    const params = {
+      key: CIVIC_API_KEY,
+      address: zipCode
+    }
+
+    if (filter != null) {
+      params.levels = filter
+    }
+
     const response = await axios.get(
       'https://www.googleapis.com/civicinfo/v2/representatives',
       {
-        params: {
-          key: CIVIC_API_KEY,
-          address: zipCode
-        }
+        params
       }
     )
+    // console.log(response.data)
 
     const { offices, officials } = response.data
     offices
@@ -39,6 +47,7 @@ router.get('/:zipCode', async (req, res) => {
       .forEach((officeType) => {
         officeType.officialIndices.forEach((position) => {
           const rep = officials[position]
+
           const repInfo = {
             name: rep.name || '',
             title: officeType.name || '',

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -39,15 +39,15 @@ router.get('/:zipCode', async (req, res) => {
         params
       }
     )
-    // console.log(response.data)
+    console.log(response)
 
     const { offices, officials } = response.data
     offices
-      .slice(2) // skip President and VP
+      .slice(0)
+      // .slice(2) // skip President and VP
       .forEach((officeType) => {
         officeType.officialIndices.forEach((position) => {
           const rep = officials[position]
-
           const repInfo = {
             name: rep.name || '',
             title: officeType.name || '',

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -21,8 +21,7 @@
                 dark
                 :style="{
                   backgroundColor:
-                    currentFilter === 'country' ? 'blue !important' : 'white',
-                  color: currentFilter === 'country' ? 'white' : 'black'
+                    currentFilter === 'country' && isActive ? 'blue' : 'gray'
                 }"
                 v-on:click="FilterList('country')"
               >
@@ -32,10 +31,10 @@
               <v-btn
                 rounded
                 dark
+                class="ui button toggle"
                 :style="{
                   backgroundColor:
-                    currentFilter === 'locality' ? 'blue !important' : 'white',
-                  color: currentFilter === 'locality' ? 'white' : 'black'
+                    currentFilter === 'locality' && isActive ? 'blue' : 'gray'
                 }"
                 v-on:click="FilterList('locality')"
               >
@@ -44,13 +43,12 @@
               <v-btn
                 rounded
                 dark
+                :class="{ active: isActive }"
                 :style="{
                   backgroundColor:
-                    currentFilter === 'administrativeArea1'
-                      ? 'blue !important'
-                      : 'white',
-                  color:
-                    currentFilter === 'administrativeArea1' ? 'white' : 'black'
+                    currentFilter === 'administrativeArea1' && isActive
+                      ? 'blue'
+                      : 'gray'
                 }"
                 v-on:click="FilterList('administrativeArea1')"
               >
@@ -59,13 +57,12 @@
               <v-btn
                 rounded
                 dark
+                :class="{ active: isActive }"
                 :style="{
                   backgroundColor:
-                    currentFilter === 'administrativeArea2'
-                      ? 'blue !important'
-                      : 'white',
-                  color:
-                    currentFilter === 'administrativeArea2' ? 'white' : 'black'
+                    currentFilter === 'administrativeArea2' && isActive
+                      ? 'blue'
+                      : 'gray'
                 }"
                 v-on:click="FilterList('administrativeArea2')"
               >
@@ -144,6 +141,8 @@ export default {
             hasContent: true,
             postalCode: this.$route.params.postalCode || '',
             listVisible: false,
+            isActive: false,
+
         }
     },
     methods: {
@@ -164,6 +163,7 @@ export default {
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
+                this.isActive = false
 
 
                 this.congressMembers = res.data
@@ -175,16 +175,17 @@ export default {
             }
         },
          async FilterList(level) {
-            this.currentFilter = level;
             try {
-                const params = {};
-                if (this.currentFilter != null) {
-                  params.filter = this.currentFilter
-                }
-                console.log(params)
+              this.currentFilter = level;
 
+                if (!this.isActive) {
+                  this.isActive = true;
+                  const params = {};
+                  if (this.currentFilter != null) {
+                    params.filter = this.currentFilter
+                  }
 
-                const res = await axios.get(
+                     const res = await axios.get(
                     '/api/representatives/' + this.postalCode,
                     {
                       params
@@ -193,6 +194,17 @@ export default {
 
              console.log(res)
                 this.congressMembers = res.data
+                } else {
+                  this.isActive = false;
+                   const res = await axios.get(
+                    '/api/representatives/' + this.postalCode
+                )
+
+
+                this.congressMembers = res.data }
+
+
+
 
 
                 } catch (e) {

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -28,6 +28,19 @@
               >
                 Federal
               </v-btn>
+
+              <v-btn
+                rounded
+                dark
+                :style="{
+                  backgroundColor:
+                    currentFilter === 'locality' ? 'blue !important' : 'white',
+                  color: currentFilter === 'locality' ? 'white' : 'black'
+                }"
+                v-on:click="FilterList('locality')"
+              >
+                Local
+              </v-btn>
               <v-btn
                 rounded
                 dark
@@ -57,18 +70,6 @@
                 v-on:click="FilterList('administrativeArea2')"
               >
                 County
-              </v-btn>
-              <v-btn
-                rounded
-                dark
-                :style="{
-                  backgroundColor:
-                    currentFilter === 'locality' ? 'blue !important' : 'white',
-                  color: currentFilter === 'locality' ? 'white' : 'black'
-                }"
-                v-on:click="FilterList('locality')"
-              >
-                Locality
               </v-btn>
             </v-row>
 

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -58,15 +58,18 @@
               >
                 County
               </v-btn>
-              <!-- <v-btn
-                                rounded
-                                dark
-                                :style="{
-         backgroundColor : currentFilter === 'locality' ? 'blue !important' : 'white',color: currentFilter ===  'locality' ? 'white' : 'black'}"
-                                v-on:click="FilterList('locality')"
-                            >
-                                Locality
-                            </v-btn> -->
+              <v-btn
+                rounded
+                dark
+                :style="{
+                  backgroundColor:
+                    currentFilter === 'locality' ? 'blue !important' : 'white',
+                  color: currentFilter === 'locality' ? 'white' : 'black'
+                }"
+                v-on:click="FilterList('locality')"
+              >
+                Locality
+              </v-btn>
             </v-row>
 
             <v-btn
@@ -160,9 +163,11 @@ export default {
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
+
+
                 this.congressMembers = res.data
                 this.hasContent = true
-                console.log(res.data)
+                // console.log(res.data)
                 this.listVisible=true
                 } catch (e) {
                 console.error(e)
@@ -175,17 +180,20 @@ export default {
                 if (this.currentFilter != null) {
                   params.filter = this.currentFilter
                 }
+                console.log(params)
+
+
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode,
-                    { params }
+                    {
+                      params
+                      }
                 )
 
+             console.log(res)
                 this.congressMembers = res.data
-                // debugger
-                // this.hasContent = true
-                // console.log(this.congressMembers)
-                // this.listVisible=true
-                // debugger
+
+
                 } catch (e) {
                 console.error(e)
             }

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -15,36 +15,60 @@
               ></v-text-field>
             </v-form>
 
-              <v-row>
-               <v-btn
+            <v-row>
+              <v-btn
+                rounded
+                dark
+                :style="{
+                  backgroundColor:
+                    currentFilter === 'country' ? 'blue !important' : 'white',
+                  color: currentFilter === 'country' ? 'white' : 'black'
+                }"
+                v-on:click="FilterList('country')"
+              >
+                Federal
+              </v-btn>
+              <v-btn
+                rounded
+                dark
+                :style="{
+                  backgroundColor:
+                    currentFilter === 'administrativeArea1'
+                      ? 'blue !important'
+                      : 'white',
+                  color:
+                    currentFilter === 'administrativeArea1' ? 'white' : 'black'
+                }"
+                v-on:click="FilterList('administrativeArea1')"
+              >
+                State
+              </v-btn>
+              <v-btn
+                rounded
+                dark
+                :style="{
+                  backgroundColor:
+                    currentFilter === 'administrativeArea2'
+                      ? 'blue !important'
+                      : 'white',
+                  color:
+                    currentFilter === 'administrativeArea2' ? 'white' : 'black'
+                }"
+                v-on:click="FilterList('administrativeArea2')"
+              >
+                County
+              </v-btn>
+              <!-- <v-btn
                                 rounded
                                 dark
                                 :style="{
-         backgroundColor : currentFilter === 'country' ? 'blue !important' : 'white',color: currentFilter ===  'country' ? 'white' : 'black'}"
-                                v-on:click="FilterList('country')"
+         backgroundColor : currentFilter === 'locality' ? 'blue !important' : 'white',color: currentFilter ===  'locality' ? 'white' : 'black'}"
+                                v-on:click="FilterList('locality')"
                             >
-                                Federal
-                            </v-btn>
-                            <v-btn
-                                rounded
-                                dark
-                                :style="{
-           backgroundColor : currentFilter === 'administrativeArea1' ? 'blue !important' : 'white',color: currentFilter === 'administrativeArea1' ? 'white' : 'black'}"
+                                Locality
+                            </v-btn> -->
+            </v-row>
 
-                                v-on:click="FilterList('administrativeArea1')"
-                            >
-                                State
-                            </v-btn>
-                            <v-btn
-                                rounded
-                                dark
-                                :style="{
-           backgroundColor : currentFilter === 'administrativeArea1' ? 'blue !important' : 'white', color:currentFilter ===  'administrativeArea2' ? 'white' : 'black'}"
-                                v-on:click="FilterList('administrativeArea1')"
-                            >
-                                County
-                            </v-btn>
-                </v-row>
             <v-btn
               :to="{
                 name: 'Reps',
@@ -101,27 +125,24 @@
 import RepresentativeCard from '@/components/RepresentativeCard.vue'
 import TakeAction from '@/components/TakeAction.vue'
 import axios from 'axios'
-
 export default {
     name: 'SearchReps',
     components: {
         RepresentativeCard,
         TakeAction
     },
-
     data () {
         return {
             letterBody: '',
             selectedRep: {},
-            currentFilter: String,
             congressMembers: [],
+            currentFilter: String,
             hasContent: true,
             postalCode: this.$route.params.postalCode || '',
             listVisible: false,
         }
     },
     methods: {
-
         handleRepSelected (letterBody, selectedRep, step2) {
             this.letterBody = letterBody
             this.selectedRep = selectedRep
@@ -134,9 +155,8 @@ export default {
                 this.hasContent = false
             }
         },
-
         async CreateRepList () {
-           try {
+            try {
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
@@ -148,9 +168,8 @@ export default {
                 console.error(e)
             }
         },
-        async FilterList(level) {
+         async FilterList(level) {
             this.currentFilter = level;
-
             try {
                 const params = {};
                 if (this.currentFilter != null) {
@@ -160,26 +179,18 @@ export default {
                     '/api/representatives/' + this.postalCode,
                     { params }
                 )
-                
+
                 this.congressMembers = res.data
                 // debugger
-                // this.hasContent = true 
+                // this.hasContent = true
                 // console.log(this.congressMembers)
                 // this.listVisible=true
                 // debugger
                 } catch (e) {
                 console.error(e)
             }
+         }
 
-            // try {
-            //     const representatives = await axios.get(
-            //         `https://www.googleapis.com/civicinfo/v2/representatives?address=${this.postalCode}&levels=${level}&key=AIzaSyAc8hv6aZUE4mmrWdqgfPMPpi8SZgH6Hww`
-            //     ); 
-            //     this.congressMembers = representatives.data.officials       
-            // } catch (e) {
-            //     console.error(e);
-            // }
-        }
     }
 }
 </script>

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -15,6 +15,36 @@
               ></v-text-field>
             </v-form>
 
+              <v-row>
+               <v-btn
+                                rounded
+                                dark
+                                :style="{
+         backgroundColor : currentFilter === 'country' ? 'blue !important' : 'white',color: currentFilter ===  'country' ? 'white' : 'black'}"
+                                v-on:click="FilterList('country')"
+                            >
+                                Federal
+                            </v-btn>
+                            <v-btn
+                                rounded
+                                dark
+                                :style="{
+           backgroundColor : currentFilter === 'administrativeArea1' ? 'blue !important' : 'white',color: currentFilter === 'administrativeArea1' ? 'white' : 'black'}"
+
+                                v-on:click="FilterList('administrativeArea1')"
+                            >
+                                State
+                            </v-btn>
+                            <v-btn
+                                rounded
+                                dark
+                                :style="{
+           backgroundColor : currentFilter === 'administrativeArea1' ? 'blue !important' : 'white', color:currentFilter ===  'administrativeArea2' ? 'white' : 'black'}"
+                                v-on:click="FilterList('administrativeArea1')"
+                            >
+                                County
+                            </v-btn>
+                </v-row>
             <v-btn
               :to="{
                 name: 'Reps',
@@ -83,6 +113,7 @@ export default {
         return {
             letterBody: '',
             selectedRep: {},
+            currentFilter: String,
             congressMembers: [],
             hasContent: true,
             postalCode: this.$route.params.postalCode || '',
@@ -90,6 +121,7 @@ export default {
         }
     },
     methods: {
+
         handleRepSelected (letterBody, selectedRep, step2) {
             this.letterBody = letterBody
             this.selectedRep = selectedRep
@@ -102,8 +134,9 @@ export default {
                 this.hasContent = false
             }
         },
+
         async CreateRepList () {
-            try {
+           try {
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
@@ -114,6 +147,38 @@ export default {
                 } catch (e) {
                 console.error(e)
             }
+        },
+        async FilterList(level) {
+            this.currentFilter = level;
+
+            try {
+                const params = {};
+                if (this.currentFilter != null) {
+                  params.filter = this.currentFilter
+                }
+                const res = await axios.get(
+                    '/api/representatives/' + this.postalCode,
+                    { params }
+                )
+                
+                this.congressMembers = res.data
+                // debugger
+                // this.hasContent = true 
+                // console.log(this.congressMembers)
+                // this.listVisible=true
+                // debugger
+                } catch (e) {
+                console.error(e)
+            }
+
+            // try {
+            //     const representatives = await axios.get(
+            //         `https://www.googleapis.com/civicinfo/v2/representatives?address=${this.postalCode}&levels=${level}&key=AIzaSyAc8hv6aZUE4mmrWdqgfPMPpi8SZgH6Hww`
+            //     ); 
+            //     this.congressMembers = representatives.data.officials       
+            // } catch (e) {
+            //     console.error(e);
+            // }
         }
     }
 }


### PR DESCRIPTION
Have reps be filterable by jurisdiction: federal, state, county

Tasks:

Create buttons in campaign.vue view
Have button filter by representative [levels](https://developers.google.com/civic-information/docs/v2/representatives/representativeInfoByAddress)
a. country = federal
b. level 1 = state
c. level 2 = county
Only show representative array that corresponds

Filter is working, however, some information is being omitted for some reason. I believe it's a stemming from the backend api that was implemented but I am unsure.



Was also wondering if there's any particular reason as to why the President and VP are skipped on the backend? I am using this same API source for filtering and noticed that some individuals would be missing in state, and county respectively when we having that splice on line #46 in the server/routes/representatives.js file... 