### PR TITLE
Fixed Integration Test Workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -37,6 +37,8 @@ jobs:
           CIVIC_API_KEY: ${{ secrets.TEST_CIVIC_API_KEY }}
           # Test environment Lob API key
           LOB_API_KEY: ${{ secrets.TEST_LOB_API_KEY }}
+          # Stripe test secret key
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
           # Auth0 authentication parameters with nonsensical sample values
           SERVER_PORT: 8080
           CLIENT_ORIGIN_URL: http://localhost:8080


### PR DESCRIPTION
# Fixed Integration Test Workflow
This PR fixes the integration test bug that originated after the introduction of Stripe in the app.

Before merging, a point needs to be addressed below. Please read the description thoroughly.

Resolves #263.

## Proof of Concept
The changes resulted in a successful run on my personal fork (with all the secrets properly configured): [Workflow Run](https://github.com/paramsiddharth/amplify/runs/7498485665?check_suite_focus=true)

![image](https://user-images.githubusercontent.com/30315706/180763977-568c9a8c-b69e-4eca-a227-19fac977622f.png)

Additionally, I had to remove line 17 to get it to work on my fork, because the condition doesn't allow the workflow to run on forks.

```diff
...
jobs:
  test:
-    if: ${{ github.repository == 'ProgramEquity/amplify' }}
    runs-on: ubuntu-latest
    timeout-minutes: 5
...
```

The change was made in a different branch than the head for this PR, so we don't need to worry about it.

## Instructions
> ⚠️ IMPORTANT
Before (or after) merging, add a new secret to the repository:
- `TEST_STRIPE_SECRET_KEY` : Set it to the Stripe test key that we are using for the app.

You can copy it from your Codespaces environment.

Once the secret is added, the PR may successfully be merged.

## Note
Once this PR is merged, other PRs having a false negative for the integration tests will no longer occur. Hence, you're encouraged to merge it as soon as possible.

Signed-off-by: Param Siddharth <contact@paramsid.com>