### PR TITLE
Add workflow to verify clean setup for Codespaces

### DIFF
--- a/.github/workflows/verify-clean-setup.yml
+++ b/.github/workflows/verify-clean-setup.yml
@@ -1,0 +1,39 @@
+name: Verify clean setup for Codespaces
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Setup node
+        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
+        with:
+          node-version-file: '.node-version'
+          # specifically do not utilize `cache: 'npm'`
+
+      - name: Run setup routine for Codespaces
+        run: ./.devcontainer/post-create-command.sh
+
+      - name: Build application
+        run: npm run build
+        env:
+          # Auth0 authentication parameters with nonsensical sample values
+          SERVER_PORT: 8080
+          CLIENT_ORIGIN_URL: http://localhost:8080
+          AUTH0_AUDIENCE: your_Auth0_identifier_value
+          AUTH0_DOMAIN: your_Auth0_domain


### PR DESCRIPTION
Adding a check to verify a hopefully clean setup for Codespaces. Doing so after running into issues with `npm install` hitting issues for peer dependency conflicts both in Codespaces and when deploying to Heroku, but NOT hitting them while running our other CI builds.

Primary difference: utilizing npm caching and `npm ci` vs. no cache and `npm install`.

The Codespaces setup script will also verify that the local developer (Codespaces) experience for database bootstrapping is not failing either. 👍🏻