### PR TITLE
Style loaders: remove SASS and update LESS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "husky": "^8.0.1",
         "jest": "^28.1.3",
         "less": "^4.1.2",
-        "less-loader": "^5.0.0",
+        "less-loader": "^7.3.0",
         "prettier": "2.6.2",
         "style-resources-loader": "^1.4.1",
         "supertest": "^6.2.3",
@@ -5923,14 +5923,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -11427,6 +11419,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/knex": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.2.0.tgz",
@@ -11521,20 +11522,57 @@
       }
     },
     "node_modules/less-loader": {
-      "version": "5.0.0",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-7.3.0.tgz",
+      "integrity": "sha512-Mi8915g7NMaLlgi77mgTTQvK022xKRQBIVDSyfl3ErTuBhmZBQab0mjeJjNNqGbdR+qrfTleKXqbGI4uEFavxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "clone": "^2.1.1",
-        "loader-utils": "^1.1.0",
-        "pify": "^4.0.1"
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
       },
       "engines": {
-        "node": ">= 4.8.0"
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "less": "^2.3.1 || ^3.0.0",
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "less": "^3.5.0 || ^4.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/less-loader/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/less-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/less/node_modules/make-dir": {
@@ -23200,10 +23238,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "dev": true
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -27099,6 +27133,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true
+    },
     "knex": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.2.0.tgz",
@@ -27176,12 +27216,38 @@
       }
     },
     "less-loader": {
-      "version": "5.0.0",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-7.3.0.tgz",
+      "integrity": "sha512-Mi8915g7NMaLlgi77mgTTQvK022xKRQBIVDSyfl3ErTuBhmZBQab0mjeJjNNqGbdR+qrfTleKXqbGI4uEFavxg==",
       "dev": true,
       "requires": {
-        "clone": "^2.1.1",
-        "loader-utils": "^1.1.0",
-        "pify": "^4.0.1"
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "leven": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,6 @@
         "less": "^4.1.2",
         "less-loader": "^5.0.0",
         "prettier": "2.6.2",
-        "sass": "^1.54.3",
-        "sass-loader": "^13.0.2",
         "style-resources-loader": "^1.4.1",
         "supertest": "^6.2.3",
         "vue-cli-plugin-style-resources-loader": "~0.1.5",
@@ -4993,6 +4991,7 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5601,6 +5600,7 @@
       "version": "3.5.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8972,6 +8972,7 @@
       "version": "5.1.2",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9597,11 +9598,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/immutable": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/import-cwd": {
       "version": "2.1.0",
       "dev": true,
@@ -9922,6 +9918,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11428,14 +11425,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/knex": {
@@ -14334,6 +14323,7 @@
       "version": "3.6.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -14764,61 +14754,6 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/sass": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.3.tgz",
-      "integrity": "sha512-fLodey5Qd41Pxp/Tk7Al97sViYwF/TazRc5t6E65O7JOk4XF8pzwIW7CvCxYVOfJFFI/1x5+elDyBIixrp+zrw==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/sass-loader": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.2.tgz",
-      "integrity": "sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==",
-      "dev": true,
-      "dependencies": {
-        "klona": "^2.0.4",
-        "neo-async": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-        "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        }
-      }
     },
     "node_modules/sax": {
       "version": "1.2.4",
@@ -15378,14 +15313,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -22591,7 +22518,8 @@
     },
     "binary-extensions": {
       "version": "2.2.0",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -23048,6 +22976,7 @@
     "chokidar": {
       "version": "3.5.2",
       "dev": true,
+      "optional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -25472,6 +25401,7 @@
     "glob-parent": {
       "version": "5.1.2",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -25893,10 +25823,6 @@
       "dev": true,
       "optional": true
     },
-    "immutable": {
-      "version": "4.0.0",
-      "dev": true
-    },
     "import-cwd": {
       "version": "2.1.0",
       "dev": true,
@@ -26103,6 +26029,7 @@
     "is-binary-path": {
       "version": "2.1.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -27170,10 +27097,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true
-    },
-    "klona": {
-      "version": "2.0.5",
       "dev": true
     },
     "knex": {
@@ -29262,6 +29185,7 @@
     "readdirp": {
       "version": "3.6.0",
       "dev": true,
+      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -29556,27 +29480,6 @@
     },
     "safer-buffer": {
       "version": "2.1.2"
-    },
-    "sass": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.3.tgz",
-      "integrity": "sha512-fLodey5Qd41Pxp/Tk7Al97sViYwF/TazRc5t6E65O7JOk4XF8pzwIW7CvCxYVOfJFFI/1x5+elDyBIixrp+zrw==",
-      "dev": true,
-      "requires": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      }
-    },
-    "sass-loader": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.2.tgz",
-      "integrity": "sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==",
-      "dev": true,
-      "requires": {
-        "klona": "^2.0.4",
-        "neo-async": "^2.6.2"
-      }
     },
     "sax": {
       "version": "1.2.4",
@@ -30006,10 +29909,6 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "dev": true
-    },
-    "source-map-js": {
-      "version": "1.0.2",
       "dev": true
     },
     "source-map-resolve": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "husky": "^8.0.1",
     "jest": "^28.1.3",
     "less": "^4.1.2",
-    "less-loader": "^5.0.0",
+    "less-loader": "^7.3.0",
     "prettier": "2.6.2",
     "style-resources-loader": "^1.4.1",
     "supertest": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,6 @@
     "less": "^4.1.2",
     "less-loader": "^5.0.0",
     "prettier": "2.6.2",
-    "sass": "^1.54.3",
-    "sass-loader": "^13.0.2",
     "style-resources-loader": "^1.4.1",
     "supertest": "^6.2.3",
     "vue-cli-plugin-style-resources-loader": "~0.1.5",


### PR DESCRIPTION
Currently, our application's Codespaces and Heroku deployments are failing due to peer dependency conflicts on LESS from merging #12.

Seems to be related to this issue: https://github.com/vuejs/vue-cli/issues/5986

**TL;DR:** Vue doesn't currently support `webpack@5.x`...? 🤔 

Current workaround:
- Remove unused `sass` and `sass-loader` dependencies
- Upgrade `less-loader` to `7.x` (newest: `11.x`), which is the latest version that supports `webpack@4.x` 😞 

```
➜ /workspaces/amplify (main) $ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: less-loader@5.0.0
npm ERR! Found: less@4.1.2
npm ERR! node_modules/less
npm ERR!   dev less@"^4.1.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer less@"^2.3.1 || ^3.0.0" from less-loader@5.0.0
npm ERR! node_modules/less-loader
npm ERR!   dev less-loader@"^5.0.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: less@3.13.1
npm ERR! node_modules/less
npm ERR!   peer less@"^2.3.1 || ^3.0.0" from less-loader@5.0.0
npm ERR!   node_modules/less-loader
npm ERR!     dev less-loader@"^5.0.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/node/.npm/eresolve-report.txt for a full report.
```