### PR TITLE
Dev/ahn nath: Add social media icons with links to representative card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^1.22.5",
         "@babel/polyfill": "^7.4.4",
+        "@fortawesome/fontawesome-svg-core": "^6.2.0",
+        "@fortawesome/free-brands-svg-icons": "^6.2.0",
+        "@fortawesome/free-regular-svg-icons": "^6.2.0",
+        "@fortawesome/free-solid-svg-icons": "^6.2.0",
+        "@fortawesome/vue-fontawesome": "^2.0.8",
         "@stripe/stripe-js": "^1.35.0",
         "@vue-stripe/vue-stripe": "^4.4.2",
         "axios": "^0.27.2",
@@ -1889,6 +1894,72 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
+      "integrity": "sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz",
+      "integrity": "sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-fm1y4NyZ2qKYNmYhdMz9VAWRw1Et7PMHNunSw3W0SVAwKwv6o0qiJworLH3Y9SnmhHzAymXJwCX1op22FFvGiA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-M1dG+PAmkYMTL9BSUHFXY5oaHwBYfHCPhbJ8qj8JELsc9XCrUJ6eEHWip4q0tE+h9C0DVyFkwIM9t7QYyCpprQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-UjCILHIQ4I8cN46EiQn0CZL/h8AwCGgR//1c4R96Q5viSRwuKVo0NdQEc4bm+69ZwC0dUvjbDqAHF1RR5FA3XA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.8.tgz",
+      "integrity": "sha512-SRmP0q9Ox4zq8ydDR/hrH+23TVU1bdwYVnugLVaAIwklOHbf56gx6JUGlwES7zjuNYqzKgl8e39iYf6ph8qSQw==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "vue": "~2"
       }
     },
     "node_modules/@hapi/address": {
@@ -20682,6 +20753,49 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
+      "integrity": "sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz",
+      "integrity": "sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-fm1y4NyZ2qKYNmYhdMz9VAWRw1Et7PMHNunSw3W0SVAwKwv6o0qiJworLH3Y9SnmhHzAymXJwCX1op22FFvGiA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-M1dG+PAmkYMTL9BSUHFXY5oaHwBYfHCPhbJ8qj8JELsc9XCrUJ6eEHWip4q0tE+h9C0DVyFkwIM9t7QYyCpprQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz",
+      "integrity": "sha512-UjCILHIQ4I8cN46EiQn0CZL/h8AwCGgR//1c4R96Q5viSRwuKVo0NdQEc4bm+69ZwC0dUvjbDqAHF1RR5FA3XA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.2.0"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.8.tgz",
+      "integrity": "sha512-SRmP0q9Ox4zq8ydDR/hrH+23TVU1bdwYVnugLVaAIwklOHbf56gx6JUGlwES7zjuNYqzKgl8e39iYf6ph8qSQw==",
+      "requires": {}
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "dev": true
@@ -21857,7 +21971,8 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -22186,7 +22301,8 @@
     },
     "@vue/cli-plugin-vuex": {
       "version": "4.5.15",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/cli-service": {
       "version": "4.5.15",
@@ -22436,7 +22552,8 @@
     },
     "@vue/preload-webpack-plugin": {
       "version": "1.1.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/web-component-wrapper": {
       "version": "1.3.0",
@@ -22638,7 +22755,8 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -22659,11 +22777,13 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -25258,7 +25378,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-vue": {
       "version": "8.7.1",
@@ -27436,7 +27557,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -29239,7 +29361,8 @@
     "pg-pool": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
-      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ=="
+      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
+      "requires": {}
     },
     "pg-protocol": {
       "version": "1.5.0"
@@ -32191,7 +32314,8 @@
       }
     },
     "vuex": {
-      "version": "3.6.2"
+      "version": "3.6.2",
+      "requires": {}
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.22.5",
     "@babel/polyfill": "^7.4.4",
+    "@fortawesome/fontawesome-svg-core": "^6.2.0",
+    "@fortawesome/free-brands-svg-icons": "^6.2.0",
+    "@fortawesome/free-regular-svg-icons": "^6.2.0",
+    "@fortawesome/free-solid-svg-icons": "^6.2.0",
+    "@fortawesome/vue-fontawesome": "^2.0.8",
     "@stripe/stripe-js": "^1.35.0",
     "@vue-stripe/vue-stripe": "^4.4.2",
     "axios": "^0.27.2",

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -137,10 +137,6 @@ router.get('/:zipCode', async (req, res) => {
           socialMediaPages: getOfficialSocialMediaPages(rep.identifiers) // call
         }
 
-        console.log(repInfo)
-        console.log('repinfo:')
-        console.log(repInfo.socialMediaPages)
-
         return repInfo
       })
 
@@ -156,6 +152,7 @@ function getOfficialSocialMediaPages(identifiers) {
 
   // loop through all the identifiers
   for (var i = 0; i < identifiers.length; i++) {
+    // social media item with data
     var identifier = identifiers[i]
 
     // switch on the identifier type and value to get the social media page and the corresponding icon
@@ -164,7 +161,7 @@ function getOfficialSocialMediaPages(identifiers) {
         social_media_pages.push({
           type: 'twitter',
           url: 'https://twitter.com/' + identifier.identifier_value,
-          icon: 'fa-solid fa-twitter'
+          icon: 'fa-brands fa-twitter'
         })
         break
 

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -110,24 +110,6 @@ router.get('/:zipCode', async (req, res) => {
           email:
             (Array.isArray(rep.email_addresses) && rep.email_addresses[0]) ||
             'Not Made Public',
-          twitter:
-            (
-              rep.identifiers.find((id) => id.identifier_type === 'TWITTER') ||
-              {}
-            ).identifier_value || 'Not Made Public',
-          facebook:
-            (
-              rep.identifiers.find(
-                (id) => id.identifier_type === 'FACEBOOK-OFFICIAL'
-              ) ||
-              rep.identifiers.find((id) => id.identifier_type === 'FACEBOOK') ||
-              rep.identifiers.find(
-                (id) => id.identifier_type === 'FACEBOOK-CAMPAIGN'
-              ) || { identifier_value: '' }
-            ).identifier_value.replace(
-              /^(?:https?:\/\/(?:www\.)?facebook\.com\/)?(.+)\/?$/,
-              '$1'
-            ) || 'Not Made Public',
           contactPage:
             rep.web_form_url || (Array.isArray(rep.urls) && rep.urls[0]) || '',
           photoUrl:

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -132,7 +132,9 @@ router.get('/:zipCode', async (req, res) => {
             rep.web_form_url || (Array.isArray(rep.urls) && rep.urls[0]) || '',
           photoUrl:
             rep.photo_origin_url ||
-            'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png'
+            'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png',
+
+          socialMediaPages: getOfficialSocialMediaPages(rep.identifiers) // call
         }
 
         return repInfo
@@ -144,6 +146,57 @@ router.get('/:zipCode', async (req, res) => {
     res.status(500).send({ error: 'Whoops' })
   }
 })
+
+function getOfficialSocialMediaPages(identifiers) {
+  var social_media_pages = []
+
+  // loop through all the identifiers
+  for (var i = 0; i < identifiers.length; i++) {
+    var identifier = identifiers[i]
+
+    // switch on the identifier type and value to get the social media page and the corresponding icon
+    switch (identifier.identifier_type) {
+      case 'TWITTER':
+        social_media_pages.push({
+          type: 'twitter',
+          url: 'https://twitter.com/' + identifier.identifier_value,
+          icon: 'fa-solid fa-twitter'
+        })
+        break
+
+      case 'FACEBOOK-OFFICIAL':
+        var new_identifier_value = identifier.identifier_value.replace(
+          /^(?:https?:\/\/(?:www\.)?facebook\.com\/)?(.+)\/?$/,
+          '$1'
+        )
+
+        social_media_pages.push({
+          type: 'facebook',
+          url: 'https://facebook.com/' + new_identifier_value,
+          icon: 'fa-brands fa-facebook-f'
+        })
+        break
+
+      case 'YOUTUBE':
+        social_media_pages.push({
+          type: 'youtube',
+          url: 'https://youtube.com/' + identifier.identifier_value,
+          icon: 'fa-brands fa-youtube'
+        })
+        break
+
+      case 'INSTAGRAM':
+        social_media_pages.push({
+          type: 'instagram',
+          url: 'https://instagram.com/' + identifier.identifier_value,
+          icon: 'fa-brands fa-instagram'
+        })
+        break
+    }
+  }
+
+  return social_media_pages
+}
 
 function formatName(rep) {
   const nameParts = []

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -161,7 +161,8 @@ function getOfficialSocialMediaPages(identifiers) {
         social_media_pages.push({
           type: 'twitter',
           url: 'https://twitter.com/' + identifier.identifier_value,
-          icon: 'fa-brands fa-twitter'
+          icon: 'fa-brands fa-twitter',
+          color: '#1DA1F2' // offiial twitter color
         })
         break
 
@@ -174,7 +175,8 @@ function getOfficialSocialMediaPages(identifiers) {
         social_media_pages.push({
           type: 'facebook',
           url: 'https://facebook.com/' + new_identifier_value,
-          icon: 'fa-brands fa-facebook-f'
+          icon: 'fa-brands fa-facebook-f',
+          color: '#4267B2' // official facebook color
         })
         break
 
@@ -182,7 +184,8 @@ function getOfficialSocialMediaPages(identifiers) {
         social_media_pages.push({
           type: 'youtube',
           url: 'https://youtube.com/' + identifier.identifier_value,
-          icon: 'fa-brands fa-youtube'
+          icon: 'fa-brands fa-youtube',
+          color: '#FF0000' // official youtube color
         })
         break
 
@@ -190,7 +193,8 @@ function getOfficialSocialMediaPages(identifiers) {
         social_media_pages.push({
           type: 'instagram',
           url: 'https://instagram.com/' + identifier.identifier_value,
-          icon: 'fa-brands fa-instagram'
+          icon: 'fa-brands fa-instagram',
+          color: '#C13584' // one of the official instagram colors
         })
         break
     }

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -137,6 +137,10 @@ router.get('/:zipCode', async (req, res) => {
           socialMediaPages: getOfficialSocialMediaPages(rep.identifiers) // call
         }
 
+        console.log(repInfo)
+        console.log('repinfo:')
+        console.log(repInfo.socialMediaPages)
+
         return repInfo
       })
 

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -27,7 +27,11 @@
         class="social-media-icon"
         onclick="window.open(this.href, '_blank'); return false;"
       >
-        <font-awesome-icon :icon="socialMedia.icon" />
+        <font-awesome-icon
+          v-bind="socialMedia"
+          :icon="socialMedia.icon"
+          style="color: socialMedia.color"
+        />
       </a>
     </div>
 

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -12,8 +12,18 @@
     </v-card-subtitle>
 
     <!-- social media icons -->
-    <div id="social-media-channel" class="text-align-left">
-      <font-awesome-icon icon="fa-solid fa-user-secret" />
+    <li v-for="{ item } in member.socialMediaPages" v-bind:key="item.icon">
+      {{ item.url }} hi
+    </li>
+
+    <div id="social-media-channel" class="text-align-left margin-left-16">
+      <!-- loop over each item -->
+      <a href="#">
+        <font-awesome-icon icon="fa-solid fa-user-secret" />
+      </a>
+      <a href="#">
+        <font-awesome-icon icon="fa-solid fa-user-secret" />
+      </a>
     </div>
 
     <v-img
@@ -73,6 +83,9 @@ export default {
 <style scoped lang="less">
 .text-align-left {
   text-align: left;
+}
+.margin-left-16 {
+  margin-left: 16px;
 }
 .rep-img {
   border-radius: 50%;

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -10,6 +10,12 @@
     <v-card-title v-text="member.name"></v-card-title>
     <v-card-subtitle v-text="member.title" class="text-align-left">
     </v-card-subtitle>
+
+    <!-- social media icons -->
+    <div id="social-media-channel" class="text-align-left">
+      <font-awesome-icon icon="fa-solid fa-user-secret" />
+    </div>
+
     <v-img
       class="text-align-left rep-img"
       v-bind:src="member.photoUrl"

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -7,27 +7,27 @@
       params: { member: member.name }
     }"
   >
-    <v-card-title v-text="member.name"></v-card-title>
-    <v-card-subtitle v-text="member.title" class="text-align-left">
+    <v-card-title v-text="member.name" class="padding-y-0"></v-card-title>
+    <v-card-subtitle
+      v-text="member.title"
+      class="text-align-left padding-y-0 margin-top-10"
+    >
     </v-card-subtitle>
 
     <!-- social media icons -->
-    <a
-      v-for="socialMedia in member.socialMediaPages"
-      :key="socialMedia.type"
-      :href="socialMedia.url"
-      target="_blank"
+    <div
+      id="social-media-channel"
+      class="text-align-left social-media-channel-box"
     >
-      {{ socialMedia.icon }}
-    </a>
-
-    <div id="social-media-channel" class="text-align-left margin-left-16">
-      <!-- loop over each item -->
-      <a href="#">
-        <font-awesome-icon icon="fa-solid fa-instagram" />
-      </a>
-      <a href="#">
-        <font-awesome-icon icon="fa-solid fa-user-secret" />
+      <a
+        v-for="socialMedia in member.socialMediaPages"
+        :key="socialMedia.type"
+        :href="socialMedia.url"
+        target="_blank"
+        class="social-media-icon"
+        onclick="window.open(this.href, '_blank'); return false;"
+      >
+        <font-awesome-icon :icon="socialMedia.icon" />
       </a>
     </div>
 
@@ -86,11 +86,16 @@ export default {
 </script>
 
 <style scoped lang="less">
+.social-media-icon {
+  margin-right: 5px;
+}
 .text-align-left {
   text-align: left;
 }
-.margin-left-16 {
+.social-media-channel-box {
   margin-left: 16px;
+  margin-top: -10px;
+  margin-bottom: 16px;
 }
 .rep-img {
   border-radius: 50%;

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -10,13 +10,7 @@
     <v-card-title v-text="member.name"></v-card-title>
     <v-card-subtitle v-text="member.title" style="text-align: left">
     </v-card-subtitle>
-    <v-img
-      style="text-align: left; border-radius: 50%; margin-left: 10px"
-      v-bind:src="member.photoUrl"
-      height="75"
-      width="75"
-    >
-    </v-img>
+
     <v-card-subtitle
       v-text="member.address_city"
       style="text-align: left"
@@ -34,13 +28,13 @@ export default {
   props: {
     member: Object
   },
-  data () {
+  data() {
     return {
     }
   },
   emits: ['handleRepSelected'],
   methods: {
-    async handleRepClick () {
+    async handleRepClick() {
       try {
         const campaignId = this.$route.params.campaignId
 

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -12,14 +12,19 @@
     </v-card-subtitle>
 
     <!-- social media icons -->
-    <li v-for="{ item } in member.socialMediaPages" v-bind:key="item.icon">
-      {{ item.url }} hi
-    </li>
+    <a
+      v-for="socialMedia in member.socialMediaPages"
+      :key="socialMedia.type"
+      :href="socialMedia.url"
+      target="_blank"
+    >
+      {{ socialMedia.icon }}
+    </a>
 
     <div id="social-media-channel" class="text-align-left margin-left-16">
       <!-- loop over each item -->
       <a href="#">
-        <font-awesome-icon icon="fa-solid fa-user-secret" />
+        <font-awesome-icon icon="fa-solid fa-instagram" />
       </a>
       <a href="#">
         <font-awesome-icon icon="fa-solid fa-user-secret" />

--- a/src/main.js
+++ b/src/main.js
@@ -13,10 +13,16 @@ import 'vuetify/dist/vuetify.min.css'
 // fontawesome icons
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faUserSecret } from '@fortawesome/free-solid-svg-icons'
+import {
+  faInstagram,
+  faFacebookF,
+  faTwitter,
+  faYoutube
+} from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 /* import specific icons */
-library.add(faUserSecret)
+library.add(faUserSecret, faInstagram, faFacebookF, faTwitter, faYoutube)
 /* add font awesome icon component */
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,16 @@ import { domain, clientId, audience } from '../auth_config.json'
 import { Auth0Plugin } from '@/auth/auth0-plugin'
 import 'vuetify/dist/vuetify.min.css'
 
+// fontawesome icons
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faUserSecret } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+/* import specific icons */
+library.add(faUserSecret)
+/* add font awesome icon component */
+Vue.component('font-awesome-icon', FontAwesomeIcon)
+
 Vue.use(Vuetify)
 
 Vue.use(Auth0Plugin, {
@@ -31,5 +41,6 @@ new Vue({
   router,
   store,
   vuetify,
+  components: { FontAwesomeIcon },
   render: (h) => h(App)
 }).$mount('#app')


### PR DESCRIPTION
Issue: #295 

🖼️: Front-end
⚙️: Back-end
🏗️: Architecture

We have completed the following:
**Process and implementation**
- **[X] ⚙️ Identify social media URLs from the identifiers property.**
- To identify social media URLs from the URLs I used Postman and chose: **Instagram, Facebook, Twitter, and Youtube** as my targets. 
**- [X] ⚙️ Improve the back-end API schema to send back social media profiles in an array.**
- I am using a function that uses the “identifiers” attribute from the representative JSON object as an argument and process the item with a switch statement to get the relevant sites and apply filters as required. I get the social media name, the social media value (username), and set the social media icon to use for it on the front end (example: fa-instagram). Then the funciton returns the array as a new property of the representative JSON that will be sent to the frontend.
**- [X] 🖼️ Display icons for known social media platforms.**
I have downloaded the FontAwesome library and have implemented it as specified in the official documentation. I felt that it was more practical than downloading svg files one by one, specially since we may be using more social media icons in the future. 


Looking forward to your comments. 