### PR TITLE
Updated gov filtering to work with Cicero API

### DIFF
--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -12,7 +12,8 @@ const JURISDICTION_FILTER_MAP = {
   federal: ['NATIONAL_UPPER', 'NATIONAL_LOWER'],
   state: ['STATE_EXEC', 'STATE_UPPER', 'STATE_LOWER'],
   county: ['COUNTY'],
-  municipality: ['LOCAL_EXEC','LOCAL']
+  municipality: ['LOCAL_EXEC','LOCAL'],
+  school: ['SCHOOL']
 }
 const ALLOWED_JURISDICTION_FILTERS = Object.keys(JURISDICTION_FILTER_MAP)
 

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -12,7 +12,7 @@ const JURISDICTION_FILTER_MAP = {
   federal: ['NATIONAL_UPPER', 'NATIONAL_LOWER'],
   state: ['STATE_EXEC', 'STATE_UPPER', 'STATE_LOWER'],
   county: ['COUNTY'],
-  municipality: ['LOCAL_EXEC','LOCAL'],
+  local: ['LOCAL_EXEC','LOCAL'],
   school: ['SCHOOL']
 }
 const ALLOWED_JURISDICTION_FILTERS = Object.keys(JURISDICTION_FILTER_MAP)

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -9,10 +9,10 @@ const router = express.Router()
 const { CICERO_API_KEY } = process.env
 
 const JURISDICTION_FILTER_MAP = {
-  federal: 'country',
-  state: 'administrativeArea1',
-  county: 'administrativeArea2',
-  municipality: 'locality'
+  federal: ['NATIONAL_UPPER', 'NATIONAL_LOWER'],
+  state: ['STATE_EXEC', 'STATE_UPPER', 'STATE_LOWER'],
+  county: ['COUNTY'],
+  municipality: ['LOCAL_EXEC','LOCAL']
 }
 const ALLOWED_JURISDICTION_FILTERS = Object.keys(JURISDICTION_FILTER_MAP)
 
@@ -40,27 +40,24 @@ router.get('/:zipCode', async (req, res) => {
   }
 
   try {
+    const params =  {
+      search_postal: zipCode,
+      search_country: 'US',
+      order: 'district_type', // https://cicero.azavea.com/docs/#order-by-district-type
+      sort: 'asc',
+      max: 200,
+      format: 'json',
+      key: CICERO_API_KEY
+    }
+
+    if (filter != null) {
+      params.district_type =  JURISDICTION_FILTER_MAP[filter]
+    }
+
     const {
       data: { response }
     } = await axios.get('https://cicero.azavea.com/v3.1/official', {
-      params: {
-        search_postal: zipCode,
-        search_country: 'US',
-        district_type: [
-          'NATIONAL_UPPER',
-          'NATIONAL_LOWER',
-          'STATE_EXEC',
-          'STATE_UPPER',
-          'STATE_LOWER',
-          'LOCAL_EXEC',
-          'LOCAL'
-        ],
-        order: 'district_type', // https://cicero.azavea.com/docs/#order-by-district-type
-        sort: 'asc',
-        max: 200,
-        format: 'json',
-        key: CICERO_API_KEY
-      },
+      params,
       paramsSerializer: (params) =>
         qs.stringify(params, { arrayFormat: 'repeat' })
     })

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -45,20 +45,6 @@
                 </v-btn>
 
                 <v-btn
-                  class="search-reps-button"
-                  rounded
-                  dark
-                  :class="{ active: isActive }"
-                  :style="{
-                    backgroundColor:
-                      currentFilter === 'county' && isActive ? 'blue' : 'gray'
-                  }"
-                  v-on:click="FilterList('county')"
-                >
-                  County
-                </v-btn>
-
-                <v-btn
                   rounded
                   dark
                   class="ui button toggle search-reps-button"
@@ -72,6 +58,21 @@
                 >
                   Local
                 </v-btn>
+
+                <v-btn
+                  class="search-reps-button"
+                  rounded
+                  dark
+                  :class="{ active: isActive }"
+                  :style="{
+                    backgroundColor:
+                      currentFilter === 'county' && isActive ? 'blue' : 'gray'
+                  }"
+                  v-on:click="FilterList('county')"
+                >
+                  County
+                </v-btn>
+
               </v-col>
             </v-row>
 

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -73,6 +73,20 @@
                   County
                 </v-btn>
 
+                <v-btn
+                  class="search-reps-button"
+                  rounded
+                  dark
+                  :class="{ active: isActive }"
+                  :style="{
+                    backgroundColor:
+                      currentFilter === 'school' && isActive ? 'blue' : 'gray'
+                  }"
+                  v-on:click="FilterList('school')"
+                >
+                  School
+                </v-btn>
+
               </v-col>
             </v-row>
 

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -50,11 +50,11 @@
                   class="ui button toggle search-reps-button"
                   :style="{
                     backgroundColor:
-                      currentFilter === 'municipality' && isActive
+                      currentFilter === 'local' && isActive
                         ? 'blue'
                         : 'gray'
                   }"
-                  v-on:click="FilterList('municipality')"
+                  v-on:click="FilterList('local')"
                 >
                   Local
                 </v-btn>


### PR DESCRIPTION
Hello (: I have updated the government level filtering to work with the Cicero API and made two other small changes. There are some concerns I had about the filtering that I listed below. Let me know your thoughts, and if anything needs improvement. Thank you!

## CHANGES MADE

- The filter map has been updated as follows:
``` js
{
  federal: ['NATIONAL_UPPER', 'NATIONAL_LOWER'],
  state: ['STATE_EXEC', 'STATE_UPPER', 'STATE_LOWER'],
  local: ['LOCAL_EXEC','LOCAL'],
  county: ['COUNTY'],
  school: ['SCHOOL']
}
```

#### Here is some insight on what the UPPER, LOWER, and EXEC designations mean:
In the U.S., both the National (also called Federal) and State government are divided into three branches: Executive Branch, Legislative Branch, and Judicial Branch. The UPPER and LOWER designations refer to the 2 chambers within the Legislative Branch. On the national level, the Upper chamber refers to U.S. Senate, and the Lower to the U.S. House of Representatives ([more info](https://www.whitehouse.gov/about-the-white-house/our-government/the-legislative-branch/)). The same applies on the state level, but called the State Senate and State House of Reps (or House of Delegates) ([more info](https://www.whitehouse.gov/about-the-white-house/our-government/state-local-government/#:~:text=All%20State%20governments%20are%20modeled,branch%20structure%20is%20not%20required.)). The EXEC designation refers to the Executive Branch. On the State level this might contain a Lieutenant Governor or State Attorney General. On the national level this contains the President, Vice President, Secretary of Defense, etc.

- The `local` map label was previously `municipality`. I changed it to "local" so that it relates with the naming conventions used within the Cicero API. Since local is a more widely understood term, I think it works better for clarity.

- I changed the ordering of the filter button components from 'federal, state, county, local' to 'federal, state, local, county, school'. Hierarchically that is what makes sense to me, we can re-order them as desired.

## ISSUES

### 1. Non-legistative district-type filters not returning results
The non-legislative district types, `COUNTY` and `SCHOOL`, rarely track officials and are consistently not returning any results. I have tested these two filter values across different US zip codes and haven't seen any officials appear. It possible that they may track officials for some locations, but it seems like its more likely to be no than yes. 

I tried searching the non-legislative districts resource directly to see what comes up, and while it does return the accurate county/school district for that zip code, the `num_officials` property is ususally 0.
![Screen Shot 2022-10-23 at 10 28 01 AM](https://user-images.githubusercontent.com/65982182/197405836-4f70df5a-f307-4bb8-b36c-14e12cff5b6b.png)

The Cicero API documentation states that 
> The types of non-legislative districts tracked by Cicero vary regionally.

([link](https://cicero.azavea.com/docs/#district-types), [database availability doc](https://s3.amazonaws.com/s3.azavea.com/com.azavea.cicero/dataavailability/Cicero_Database_Availability.pdf)) 

Which suggests to me that the content of this resource may not be fully developed or consistent. I might not be understanding this correctly though, so feel free to clarify on this.

You can test it yourself here:

[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/20590745-16fe025b-bb49-4ddc-8c5d-bf04047555d3?action=collection%2Ffork&collection-url=entityId%3D20590745-16fe025b-bb49-4ddc-8c5d-bf04047555d3%26entityType%3Dcollection%26workspaceId%3D1497ca06-fa06-4516-9272-9ce4a98e094b)

#### An alternative mapping would be:

``` js
{
  federal: ['NATIONAL_UPPER', 'NATIONAL_LOWER'],
  state: ['STATE_EXEC'],
  local: ['STATE_UPPER', 'STATE_LOWER'],
  county: ['LOCAL_EXEC', 'LOCAL' ],
  school: ['SCHOOL']
}
```

This might work better as the representatives tracked within the `LOCAL` and `LOCAL_EXEC` values are mostly county/city level officials. With this mapping, officials listed under the State filter would be state executives (like the governor, state attorney general), under Local would be be state reps and delegates, and under County would be county/city officials. This is also in line with how we applied the filtering with the Civic API, so I think this would be the better option, let me know your thoughts.

### 2. Rep list with no filter looks the same for every zip code
If no filter is provided the default behavior I've coded is to not pass a `district_type` property into the API, therefore all officials (minus the ones we have filtered out manually i.e. President, Vice President) corresponding to that zip code are listed. The first 10-15 people on the list is the same for every zip code since we are ordering officials by "district_type" ([more info](https://cicero.azavea.com/docs/#order-by-district-type)) which positions national executives first . 

![zipcodes_example](https://user-images.githubusercontent.com/65982182/197404851-ef198c9b-74e6-43f7-b3a1-cd908d2836a3.gif)

If this isn't desired, and we want the list to vary, we can update the default behavior to exclude national executives, so that users see the U.S. Senators and Representatives for that zip code first. This can be done by assigning a default list to `district_type` , which excludes the `NATIONAL_EXEC` value. We can then modify the list depending on if a filter was passed before sending that information to the API. 

--
Thanks for reviewing, let me know if anything doesn't make sense, or if I'm going about this the wrong way. Looking forward to your comments (:

Resolves #271 