### PR TITLE
Ahn nath/cache option apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "lob": "^6.6.3",
         "objection": "^3.0.1",
         "pg": "^8.7.3",
+        "redis": "^4.3.1",
         "register-service-worker": "^1.7.1",
         "stripe": "^8.219.0",
         "vue": "^2.6.11",
@@ -2515,6 +2516,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+      "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+      "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+      "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+      "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@sideway/address": {
@@ -6059,6 +6118,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9253,6 +9320,14 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "license": "MIT"
+    },
+    "node_modules/generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -14897,6 +14972,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+      "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+      "dependencies": {
+        "@redis/bloom": "1.0.2",
+        "@redis/client": "1.3.0",
+        "@redis/graph": "1.0.1",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.0",
+        "@redis/time-series": "1.0.3"
       }
     },
     "node_modules/regenerate": {
@@ -21255,6 +21343,53 @@
     "@panva/asn1.js": {
       "version": "1.0.0"
     },
+    "@redis/bloom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+      "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+      "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+      "requires": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@redis/graph": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+      "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+      "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+      "requires": {}
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -23948,6 +24083,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -26262,6 +26402,11 @@
     },
     "function-bind": {
       "version": "1.1.1"
+    },
+    "generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -30248,6 +30393,19 @@
       "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "requires": {
         "resolve": "^1.20.0"
+      }
+    },
+    "redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+      "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+      "requires": {
+        "@redis/bloom": "1.0.2",
+        "@redis/client": "1.3.0",
+        "@redis/graph": "1.0.1",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.0",
+        "@redis/time-series": "1.0.3"
       }
     },
     "regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@stripe/stripe-js": "^1.35.0",
         "@vue-stripe/vue-stripe": "^4.4.2",
         "axios": "^0.27.2",
+        "axios-cache-interceptor": "^0.10.7",
         "cli-plugin-eslint": "^0.1.0",
         "connect-history-api-fallback": "^2.0.0",
         "dotenv": "^16.0.3",
@@ -4793,6 +4794,19 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/axios-cache-interceptor": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-0.10.7.tgz",
+      "integrity": "sha512-UjpxChG5DpF6Kf1IPGMLOzRDNL8ZNS6TOn1jTaVvCE7cWFU904jJwi0T1s+IbijpnLEjK2iq5uLIuR8Sj+RsFQ==",
+      "dependencies": {
+        "cache-parser": "^1.2.4",
+        "fast-defer": "^1.1.7",
+        "object-code": "^1.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/ArthurFiorette/axios-cache-interceptor?sponsor=1"
+      }
+    },
     "node_modules/babel-extract-comments": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
@@ -5516,6 +5530,11 @@
       "peerDependencies": {
         "webpack": "^4.0.0"
       }
+    },
+    "node_modules/cache-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -8640,6 +8659,11 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/fast-defer": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "node_modules/fast-glob": {
       "version": "2.2.7",
@@ -13017,6 +13041,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/object-code": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
@@ -22986,6 +23015,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "axios-cache-interceptor": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-0.10.7.tgz",
+      "integrity": "sha512-UjpxChG5DpF6Kf1IPGMLOzRDNL8ZNS6TOn1jTaVvCE7cWFU904jJwi0T1s+IbijpnLEjK2iq5uLIuR8Sj+RsFQ==",
+      "requires": {
+        "cache-parser": "^1.2.4",
+        "fast-defer": "^1.1.7",
+        "object-code": "^1.2.4"
+      }
+    },
     "babel-extract-comments": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
@@ -23550,6 +23589,11 @@
         "neo-async": "^2.6.1",
         "schema-utils": "^2.0.0"
       }
+    },
+    "cache-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -25768,6 +25812,11 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3"
+    },
+    "fast-defer": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -28887,6 +28936,11 @@
     "object-assign": {
       "version": "4.1.1",
       "dev": true
+    },
+    "object-code": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "lob": "^6.6.3",
     "objection": "^3.0.1",
     "pg": "^8.7.3",
-    "redis": "^4.3.1",
     "register-service-worker": "^1.7.1",
     "stripe": "^8.219.0",
     "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@stripe/stripe-js": "^1.35.0",
     "@vue-stripe/vue-stripe": "^4.4.2",
     "axios": "^0.27.2",
+    "axios-cache-interceptor": "^0.10.7",
     "cli-plugin-eslint": "^0.1.0",
     "connect-history-api-fallback": "^2.0.0",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lob": "^6.6.3",
     "objection": "^3.0.1",
     "pg": "^8.7.3",
+    "redis": "^4.3.1",
     "register-service-worker": "^1.7.1",
     "stripe": "^8.219.0",
     "vue": "^2.6.11",

--- a/server/__tests__/integration/axios-cache-interceptor.test.js
+++ b/server/__tests__/integration/axios-cache-interceptor.test.js
@@ -1,16 +1,16 @@
 require('dotenv').config()
-// import required dependencies for cache interceptor to work
 const Axios = require('axios')
 const { setupCache } = require('axios-cache-interceptor')
 
-// to test: npm test -- axios-cache-interceptor.test.js
-// 1. we test that the configuration we set is valid and available
+// 1. we test that the configuration we set is valid and available to check
 describe('test Axios configuration', () => {
   test('tests argument composition', () => {
     const axios = Axios.create()
     const withAxios = setupCache(axios)
+    // we expect axios to be properly configured with setupCache
     expect(withAxios).not.toBeUndefined()
 
+    // we expect the cache to be properly configured and contain our properties after initialization
     const withConfig = setupCache(axios, { ttl: 1234 })
     expect(withConfig).not.toBeUndefined()
     expect(withConfig.defaults.cache.ttl).toBe(1234)
@@ -23,17 +23,35 @@ describe('test Axios cache with concurrent requests', () => {
     const axios = Axios.create()
     const cache_interceptor = setupCache(axios)
 
-    // the response is cached. Reference: https://apipheny.io/free-api/
+    // we make two concurrent requests to the same endpoint
     const req1 = cache_interceptor.get('https://api.publicapis.org/entries')
     const req2 = cache_interceptor.get('https://api.publicapis.org/entries/')
-
-    // req1 and req2 are the same promise
     const [res1, res2] = await Promise.all([req1, req2])
 
-    // assertions
+    // assertions: we expect the second response to be cached
     expect(res1.cached).toBe(false)
     expect(res2.cached).toBe(true)
   })
 })
 
 // 3. we test that the cache is invalidated when the ttl expires
+describe('test Axios cache invalidation option', () => {
+  test('tests cache invalidation', async () => {
+    // we set the ttl to 10 seconds
+    const axios = Axios.create()
+    const cache_interceptor = setupCache(axios, { ttl: 10000 })
+    // we make two concurrent requests
+    const req1 = cache_interceptor.get('https://api.publicapis.org/entries')
+    const req2 = cache_interceptor.get('https://api.publicapis.org/entries/')
+    const [res1, res2] = await Promise.all([req1, req2])
+    // assertions: the first is never cached, we expect the second to be cached
+    expect(res1.cached).toBe(false)
+    expect(res2.cached).toBe(true)
+    // we wait for 10.1 seconds and make another call
+    await new Promise((resolve) => setTimeout(() => resolve(), 11000))
+    const req3 = cache_interceptor.get('https://api.publicapis.org/entries')
+    const res3 = await req3
+    // assertions: the third is expected not to be cached, due to the ttl
+    expect(res3.cached).toBe(false)
+  }, 70000)
+})

--- a/server/__tests__/integration/axios-cache-interceptor.test.js
+++ b/server/__tests__/integration/axios-cache-interceptor.test.js
@@ -1,0 +1,39 @@
+require('dotenv').config()
+// import required dependencies for cache interceptor to work
+const Axios = require('axios')
+const { setupCache } = require('axios-cache-interceptor')
+
+// to test: npm test -- axios-cache-interceptor.test.js
+// 1. we test that the configuration we set is valid and available
+describe('test Axios configuration', () => {
+  test('tests argument composition', () => {
+    const axios = Axios.create()
+    const withAxios = setupCache(axios)
+    expect(withAxios).not.toBeUndefined()
+
+    const withConfig = setupCache(axios, { ttl: 1234 })
+    expect(withConfig).not.toBeUndefined()
+    expect(withConfig.defaults.cache.ttl).toBe(1234)
+  })
+})
+
+// 2. we test that the cache is working as expected with concurrent requests
+describe('test Axios cache with concurrent requests', () => {
+  test('tests cache', async () => {
+    const axios = Axios.create()
+    const cache_interceptor = setupCache(axios)
+
+    // the response is cached. Reference: https://apipheny.io/free-api/
+    const req1 = cache_interceptor.get('https://api.publicapis.org/entries')
+    const req2 = cache_interceptor.get('https://api.publicapis.org/entries/')
+
+    // req1 and req2 are the same promise
+    const [res1, res2] = await Promise.all([req1, req2])
+
+    // assertions
+    expect(res1.cached).toBe(false)
+    expect(res2.cached).toBe(true)
+  })
+})
+
+// 3. we test that the cache is invalidated when the ttl expires

--- a/server/__tests__/integration/axios-cache-interceptor.test.js
+++ b/server/__tests__/integration/axios-cache-interceptor.test.js
@@ -18,15 +18,16 @@ describe('test Axios configuration', () => {
 })
 
 // 2. we test that the cache is working as expected with concurrent requests
-describe('test Axios cache with concurrent requests', () => {
+describe('test Axios cache with two requests', () => {
   test('tests cache', async () => {
     const axios = Axios.create()
     const cache_interceptor = setupCache(axios)
 
-    // we make two concurrent requests to the same endpoint
+    // we make two sequential requests to the same api endpoint
     const req1 = cache_interceptor.get('https://api.publicapis.org/entries')
     const req2 = cache_interceptor.get('https://api.publicapis.org/entries/')
-    const [res1, res2] = await Promise.all([req1, req2])
+    const res1 = await req1
+    const res2 = await req2
 
     // assertions: we expect the second response to be cached
     expect(res1.cached).toBe(false)
@@ -40,18 +41,13 @@ describe('test Axios cache invalidation option', () => {
     // we set the ttl to 10 seconds
     const axios = Axios.create()
     const cache_interceptor = setupCache(axios, { ttl: 10000 })
-    // we make two concurrent requests
-    const req1 = cache_interceptor.get('https://api.publicapis.org/entries')
-    const req2 = cache_interceptor.get('https://api.publicapis.org/entries/')
-    const [res1, res2] = await Promise.all([req1, req2])
-    // assertions: the first is never cached, we expect the second to be cached
-    expect(res1.cached).toBe(false)
-    expect(res2.cached).toBe(true)
-    // we wait for 10.1 seconds and make another call
+    // we make a simple request
+    cache_interceptor.get('https://api.publicapis.org/entries')
+    // we wait for 11 seconds and make another call
     await new Promise((resolve) => setTimeout(() => resolve(), 11000))
     const req3 = cache_interceptor.get('https://api.publicapis.org/entries')
     const res3 = await req3
-    // assertions: the third is expected not to be cached, due to the ttl
+    // assertions: the second request is expected not to be cached, due to the ttl
     expect(res3.cached).toBe(false)
   }, 70000)
 })

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -93,7 +93,11 @@ router.get('/:zipCode', async (req, res) => {
         key: CICERO_API_KEY
       },
       paramsSerializer: (params) =>
-        qs.stringify(params, { arrayFormat: 'repeat' })
+        qs.stringify(params, { arrayFormat: 'repeat' }),
+
+      cache: {
+        ttl: 1000 * 60 * 10080 // the time until the cached value is expired in milliseconds: set to 1 week
+      }
     })
 
     // check if response was cached

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -31,7 +31,7 @@ const STORAGE = buildStorage({
     CACHE.delete(key)
   }
 })
-// set up caxios-cache-interceptor with redis storage as a persistent storage
+// set up caxios-cache-interceptor with the map as a persistent storage
 const axios = setupCache(Axios, { storage: STORAGE })
 
 const router = express.Router()
@@ -71,8 +71,8 @@ router.get('/:zipCode', async (req, res) => {
 
   try {
     const {
-      data: { response },
-      cached
+      data: { response }
+      //cached
     } = await axios.get('https://cicero.azavea.com/v3.1/official', {
       params: {
         search_postal: zipCode,
@@ -100,8 +100,8 @@ router.get('/:zipCode', async (req, res) => {
       }
     })
 
-    // check if response was cached
-    console.log('isCached:', cached)
+    // if you want to check if response was cached, uncomment: this is a way to track the issue
+    // console.log('isCached:', cached)
 
     const { errors, results } = response
     if (errors.length > 0) {

--- a/src/components/RepresentativeCard.vue
+++ b/src/components/RepresentativeCard.vue
@@ -7,17 +7,20 @@
     }"
     @click="handleRepClick"
   >
-    <v-card-title class="justify-center" v-text="member.name" />
+    <v-card-title class="padding-y-0" v-text="member.name" />
     <v-card-subtitle
-      class="text-center padding-y-0 margin-top-10"
+      class="text-align-left padding-y-0 margin-top-10"
       v-text="member.title"
     />
 
     <!-- social media icons -->
-    <div id="social-media-channel" class="text-center social-media-channel-box">
+    <div
+      id="social-media-channel"
+      class="text-align-left social-media-channel-box"
+    >
       <a
         v-for="socialMedia in member.socialMediaPages"
-        :key="socialMedia.type"
+        :key="socialMedia.url"
         :href="socialMedia.url"
         target="_blank"
         class="social-media-icon"
@@ -32,12 +35,15 @@
     </div>
 
     <v-img
-      class="mx-auto rep-img"
-      :src="member.photoUrl"
+      class="text-align-left rep-img"
+      v-bind:src="member.photoUrl"
       height="75"
       width="75"
     />
-    <v-card-subtitle class="text-center rep-img" v-text="member.address_city" />
+    <v-card-subtitle
+      v-text="member.address_city"
+      class="text-align-left rep-img"
+    />
   </v-card>
 </template>
 
@@ -45,20 +51,17 @@
 import axios from 'axios'
 
 export default {
-  name: 'RepresentativeCard',
+  name: 'representative-card',
   components: {
   },
   props: {
-    member: {
-      type: Object,
-      required: true
-    }
+    member: Object
   },
-  emits: ['handleRepSelected'],
   data() {
     return {
     }
   },
+  emits: ['handleRepSelected'],
   methods: {
     async handleRepClick() {
       try {

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -150,12 +150,7 @@
 import RepresentativeCard from '@/components/RepresentativeCard.vue'
 import TakeAction from '@/components/TakeAction.vue'
 import axios from 'axios'
-//import { setupCache, buildWebStorage } from 'axios-cache-interceptor';
 
-// setting up axios with axios-cache-interceptor
-// set persistent storage to localStorage
-//const myStorage = buildWebStorage(localStorage, 'axios-cache:');
-//const axios = setupCache(Axios, {storage: myStorage, maxAge: 15 * 60 * 1000});
 export default {
     name: 'SearchReps',
     components: {

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -136,6 +136,7 @@
 import RepresentativeCard from '@/components/RepresentativeCard.vue'
 import TakeAction from '@/components/TakeAction.vue'
 import axios from 'axios'
+import { setupCache } from 'axios-cache-interceptor';
 export default {
     name: 'SearchReps',
     components: {
@@ -169,14 +170,18 @@ export default {
         },
         async CreateRepList () {
             try {
+                // setting up axios with axios-cache-interceptor
+                const axios = setupCache(axios);
+
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
                 this.isActive = false
-
+                // TODO: delete this as soon as you are confident about the changes
+                console.log(res)
+                console.log(res.cached);
                 this.congressMembers = res.data
                 this.hasContent = true
-                // console.log(res.data)
                 this.listVisible = true
             } catch (e) {
                 console.error(e)

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -150,7 +150,12 @@
 import RepresentativeCard from '@/components/RepresentativeCard.vue'
 import TakeAction from '@/components/TakeAction.vue'
 import axios from 'axios'
-import { setupCache } from 'axios-cache-interceptor';
+//import { setupCache, buildWebStorage } from 'axios-cache-interceptor';
+
+// setting up axios with axios-cache-interceptor
+// set persistent storage to localStorage
+//const myStorage = buildWebStorage(localStorage, 'axios-cache:');
+//const axios = setupCache(Axios, {storage: myStorage, maxAge: 15 * 60 * 1000});
 export default {
     name: 'SearchReps',
     components: {
@@ -184,16 +189,10 @@ export default {
         },
         async CreateRepList() {
             try {
-                // setting up axios with axios-cache-interceptor
-                const axios = setupCache(axios);
-
                 const res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
                 this.isActive = false
-                // TODO: delete this as soon as you are confident about the changes
-                console.log(res)
-                console.log(res.cached);
                 this.congressMembers = res.data
                 this.hasContent = true
                 this.listVisible = true


### PR DESCRIPTION
Closes #294 
We have explored a caching option with the library [axios-cache-interceptor](https://github.com/arthurfiorette/axios-cache-interceptor) to “cache API calls to reduce the number of credits we use”. For this caching option we need to see the lifetime of a cached response, a way to persist the day permanently and across different user sessions and, keep in mind, the margin to consider for cutting expenses. 

- [x] Add pull request description
- [x] Add persistent storage
- [x] Set options to invalidate cache and the lifetime of a cached response

### Description of relevant aspects:
**Set options to invalidate the cache and the lifetime of a cached response**
To define a limit or deadline for a cached response to be valid and updated, we make use of the property "ttl", as part of the “per request configuration”. We set it to the reasonable time limit of 1 week in milliseconds: 604800000.
```
// The time until the cached value is expired in milliseconds.
    ttl: 1000 * 60 * 10080,
```
 Source: https://axios-cache-interceptor.js.org/#/pages/per-request-configuration?id=cachettl

**Add persistent storage**
The lifetime of a request will only make sense and work if we use persistent storage. There are several options they provide, such as:

- In memory: that will not be persistent and will easily be lost with a page reload.
- Web storage: it has sessions and across sessions (works with a browser Window and dies as soon as it is closed)
- Custom storage: which can last more time.

I am not considering using a database. Instead, I think we can use documents that are stored in the file system for persistence or variables that are initialized once during the server lifetime. I am using a Map structure that is working with the `buildStorage` function of the library.

**Considerations:**
- If the app/amplify project uses several servers to work with the representatives' data, libraries that help you persist the data elsewhere may be a better option, such as [Node Redis](https://github.com/redis/node-redis). Now, this simpler solution can prevent the complexity such a library would add and provide a working option that fits our case. I am open to your comments and suggestions if my judgment is incorrect. 

- I discussed with my mentors that in some cases, when important data changes, we may need to update the website data as soon as possible, and not wait until the scheduled time to refresh the API comes. Such a case is when we need to send a letter and require a valid address. In those cases, as suggested by my mentors @thyeggman and @paramsiddharth, an alternative would be to make a real API call and update the caching storage as per demand, or when the user triggers the function responsible for sending the letter. 

**Results and the effect of this implementation**
![image](https://user-images.githubusercontent.com/67247850/198399172-e196e160-faaf-41dd-923d-90b622cdadec.png)

On average, we could assume that **I make 9 calls per day**, with **a total of 63 calls per week**. If we are only making real API calls (updating the cache) once a week, that is, only making one call to the API per week, we are using, roughly, 1.58% of the current average. For that case, we would be cutting 98.5% of our weekly use. 

