### PR TITLE
Correct submission behavior for postal form

### DIFF
--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -7,7 +7,7 @@
             <v-card-text>
               <v-subheader class="pa-0"> Where do you live? </v-subheader>
 
-              <v-form ref="form">
+              <v-form @submit.prevent="CreateRepList()" ref="form">
                 <v-text-field
                   v-model="postalCode"
                   label="Postal Code"


### PR DESCRIPTION
For the postal form submission we wanted to:
- recreate the `on-click` behaviour exhibited by the submit button
-  prevent the default form submission behaviour, which refreshes the page

### Solution
I used the `.prevent` [event modifier](https://vuejs.org/guide/essentials/event-handling.html#event-modifiers) to prevent the default submission behavior so that pressing enter no longer refreshes the page, but instead executes the CreateRepList function to display the representatives.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/65982182/200613509-a73498ae-5db4-4471-94ec-054fcbe14a1a.gif)

--
Resolves #293 