### PR TITLE
Added more GitHub usernames to Slack mention action

### DIFF
--- a/.github/mention-to-slack.yml
+++ b/.github/mention-to-slack.yml
@@ -3,7 +3,18 @@
 # For GitHub team:
 # github_teamname: "slack_member_id"
 
+# Team
 manishapriya94: 'U014PTUCF45'
+JamesMGreene: 'U020NHEBUPM'
+DietBepis1: 'U03K6HNBNNP'
+thyeggman: 'U03JUQDB8CB'
+paramsiddharth: 'U03J5KZVDM3'
+eprice555: 'U03UZQDA5DL'
+wallace: 'U02M9M81WUS'
+gdomingu: 'U03JVS4G334'
+ipc103: 'U046UL9BS9M'
+therzka: 'U03V8PPKR6H'
+joeyouss: 'U043YKQND98'
 
 # Fellows
 tdo95: 'U0457B11TLY'


### PR DESCRIPTION
# Added more GitHub usernames to Slack mention action
The Slack mention feature is really great. We would be able to make the best use of it add a couple more of the relevant folks in the project's maintenance, development, and/or mentorship.

## New users
```yaml
JamesMGreene: 'U020NHEBUPM'
DietBepis1: 'U03K6HNBNNP'
thyeggman: 'U03JUQDB8CB'
paramsiddharth: 'U03J5KZVDM3'
eprice555: 'U03UZQDA5DL'
wallace: 'U02M9M81WUS'
gdomingu: 'U03JVS4G334'
ipc103: 'U046UL9BS9M'
therzka: 'U03V8PPKR6H'
joeyouss: 'U043YKQND98'
```