### PR TITLE
Add another API call to the app which accepts an address in its body

### DIFF
--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -129,6 +129,17 @@ router.get('/:zipCode', async (req, res) => {
   }
 })
 
+router.post('/districts', async (req, res) => {
+  const { address } = req.body
+
+  try {
+    console.log('address', address)
+  } catch (error) {
+    console.log(error)
+    res.status(500).send({ error: 'Whoops' })
+  }
+})
+
 function getOfficialSocialMediaPages(identifiers) {
   var social_media_pages = []
 

--- a/src/components/SearchReps.vue
+++ b/src/components/SearchReps.vue
@@ -183,14 +183,31 @@ export default {
         },
         async CreateRepList() {
             try {
-                const res = await axios.get(
+
+                // check postal code is valid with regex
+                let res = ''
+                let isPostalCodeValid =  /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(this.postalCode);
+                if(!isPostalCodeValid) {
+                  res = await axios.get(
                     '/api/representatives/' + this.postalCode
                 )
-                this.isActive = false
+                }else{
+                  // check if street address is valid with a flexible regex. This validation is not perfect, but caches common cases
+                  // [a-zA-Z0-9\s]	Any single character in the range a-z or A-Z or 0-9 or whitespace
+                  // '-	Matches the characters - (case sensitive)
+                  // * 0 or more times
+                  // $  end of string
+                  let streetAddressValid = /^[a-zA-Z0-9\s,'-]*$/.test(this.postalCode);
+                  if(streetAddressValid){
+                  res = await axios.post(
+                    '/api/representatives/districts', {address: this.postalCode}
+                  )
+                  }
+                }
 
+                this.isActive = false
                 this.congressMembers = res.data
                 this.hasContent = true
-                // console.log(res.data)
                 this.listVisible = true
             } catch (e) {
                 console.error(e)


### PR DESCRIPTION
> Enable searches by address in order for the Cicero API to return only the results for the legislative districts for that point. This will give more granularity to search results for local representatives, and there won't be representatives presented outside the sender's legislative area(s). Since we have caching already, this should mitigate the effects of increased cost due to additional granularity in results.

- [ ] Add another API call to the app which accepts an address in its body
- [ ]  Feed the address information to the [cicero address API](https://cicero.azavea.com/docs/#address)
- [ ]  Update the Amplify App UI to call the new endopint if the search term looks like an address
- [ ]  Follow up on the caching – we currently use the ZIP code as the key, but we'll need to think of different addresses may refer to the same set of reps