### PR TITLE
Add octref.vetur extension to add Vue editor support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
     "dbaeumer.vscode-eslint",
     "mtxr.sqltools",
     "mtxr.sqltools-driver-pg",
-    "octref.vetur"
+    "Vue.volar"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
   "extensions": [
     "dbaeumer.vscode-eslint",
     "mtxr.sqltools",
-    "mtxr.sqltools-driver-pg"
+    "mtxr.sqltools-driver-pg",
+    "octref.vetur"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Closes https://github.com/ProgramEquity/amplify/issues/86

This adds [an extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) that adds editor support for the Vue framework.