### PR TITLE
Fix to formatting for scroll-behavior file.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,7 +4,6 @@ import Home from '../views/Home.vue'
 import SearchReps from '../components/SearchReps'
 import RepresentativeCard from '../components/RepresentativeCard'
 import scrollBehavior from './scroll-behavior'
-import App from '/src/App.vue'
 // import Reps from '../components/Reps'
 
 Vue.use(VueRouter)
@@ -54,10 +53,5 @@ const router = new VueRouter({
   base: process.env.BASE_URL,
   routes
 })
-
-new Vue({
-  router,
-  render: (h) => h(App)
-}).$mount('#app')
 
 export default router

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,8 @@ import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
 import SearchReps from '../components/SearchReps'
 import RepresentativeCard from '../components/RepresentativeCard'
+import scrollBehavior from './scroll-behavior'
+import App from '/workspace/src/App.vue'
 // import Reps from '../components/Reps'
 
 Vue.use(VueRouter)
@@ -48,8 +50,14 @@ const routes = [
 
 const router = new VueRouter({
   mode: 'history',
+  scrollBehavior,
   base: process.env.BASE_URL,
   routes
 })
+
+new Vue({
+  router,
+  render: (h) => h(App)
+}).$mount('#app')
 
 export default router

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,7 +4,7 @@ import Home from '../views/Home.vue'
 import SearchReps from '../components/SearchReps'
 import RepresentativeCard from '../components/RepresentativeCard'
 import scrollBehavior from './scroll-behavior'
-import App from '/workspace/src/App.vue'
+import App from '/src/App.vue'
 // import Reps from '../components/Reps'
 
 Vue.use(VueRouter)

--- a/src/router/scroll-behavior.js
+++ b/src/router/scroll-behavior.js
@@ -1,0 +1,9 @@
+const scrollBehavior = (to, from, savedPosition) => {
+  if (savedPosition) {
+    return savedPosition
+  } else {
+    return { x: 0, y: 0 }
+  }
+}
+
+export default scrollBehavior


### PR DESCRIPTION
**Issue**
"Currently, when a page is taller than a device's viewport, if a user navigates to another page (i.e. home to campaign, etc.) the viewport will remain at the coordinates of the previous page."

**Fix**
Creation of scroll-behavior file and implementation in index file in router. Page now reverts to 0, 0 upon navigation to new page.