### PR TITLE
Fix Part 1 for Issue #407

### DIFF
--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -129,53 +129,59 @@ router.get('/:searchText', async (req, res) => {
   let response
 
   if (error) {
-    const test_response = {
-      errors: [],
-      results: {
-        candidates: [
-          {
-            officials: [
-              // rep:
-              {
-                office: {
-                  district: {
-                    ocd_id: 1234
-                  },
-                  title: 'Office Title'
-                },
-                chamber: {
-                  name_formal: 'Chamber Formal Name',
-                  name: 'Name of Chamber'
-                },
-                addresses: [
-                  // mainAddr:
-                  {
-                    address_1: '123 Main',
-                    address_2: 'Apt 321',
-                    city: 'City',
-                    postal_code: '00000',
-                    state: 'California'
-                  }
-                ],
-                web_form_url: 'https://fake_web_form_url.com',
-                email_addresses: 'fake_email@failed_request.com',
-                photo_origin_url: 'https://fake_photo_origin_url.com',
-                identifiers: [],
-                photo_cropping: {}
-              }
-            ]
-          }
-        ]
-      }
-    }
-
-    response = test_response
-
     // http://127.0.0.1:8080/api/representatives/91765 get request failed
-    // console.error(error) // uncomment only when debugging
-    res.status(500).send({
-      error: `Whoops, the request for getting representatives from 'https://cicero.azavea.com/v3.1/official' failed. A test response is generated.`
-    })
+    // uncomment only when debugging
+    // console.error(error)
+
+    // to avoid server crashing so front-end work can continue, add NODE_ENV='development' to your .env
+    if (process.env.NODE_ENV === 'development') {
+      // a test_response helpful for front-end work when axios requests are not working
+      const test_response = {
+        errors: [],
+        results: {
+          candidates: [
+            {
+              officials: [
+                // rep:
+                {
+                  office: {
+                    district: {
+                      ocd_id: 1234
+                    },
+                    title: 'Office Title'
+                  },
+                  chamber: {
+                    name_formal: 'Chamber Formal Name',
+                    name: 'Name of Chamber'
+                  },
+                  addresses: [
+                    // mainAddr:
+                    {
+                      address_1: '123 Main',
+                      address_2: 'Apt 321',
+                      city: 'City',
+                      postal_code: '00000',
+                      state: 'California'
+                    }
+                  ],
+                  web_form_url: 'https://fake_web_form_url.com',
+                  email_addresses: 'fake_email@failed_request.com',
+                  photo_origin_url: 'https://fake_photo_origin_url.com',
+                  identifiers: [],
+                  photo_cropping: {}
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      response = test_response
+    } else {
+      res.status(500).send({
+        error: `Whoops, the request for getting representatives from 'https://cicero.azavea.com/v3.1/official' failed. A test response is generated.`
+      })
+    }
   } else {
     response = received.data // axios' way of handling returned data
   }

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -189,14 +189,16 @@ router.get('/:searchText', async (req, res) => {
     res.send(representatives)
   } catch (error) {
     console.log(error)
-    res.status(500).send({ error: 'Whoops' })
+    res.status(500).send({
+      error: `Whoops, likely the axios.get req for getting representatives from 'https://cicero.azavea.com/v3.1/official' failed.`
+    })
   }
 })
 
 /*
  * Returns string with the following properties:
  *  - x-value: right or left. Indicates whether the photo should be cropped/positioned from the left or right side.
- *  - y-value: top or bottom. Indicates whether the photo should be cropped/psoitioned from the top or bottom side.
+ *  - y-value: top or bottom. Indicates whether the photo should be cropped/positioned from the top or bottom side.
  *
  * Example: "top left"
  *

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -31,7 +31,7 @@ const STORAGE = buildStorage({
     CACHE.delete(key)
   }
 })
-// set up caxios-cache-interceptor with the map as a persistent storage
+// set up axios-cache-interceptor with the map as a persistent storage
 const axios = setupCache(Axios, { storage: STORAGE })
 
 const router = express.Router()
@@ -65,7 +65,7 @@ router.get('/:searchText', async (req, res) => {
   /* check if valid street address
      ^(\d{3,})\s? the start of the line can have 3 or more digits followed by a space
      (\w{0,})\s the next part can have 2 or more letters followed by a space
-     ([a-zA-Z]{2,30})\s the next part must be an alphanetical string with 2-30 characters followed by a space
+     ([a-zA-Z]{2,30})\s the next part must be an alphabetical string with 2-30 characters followed by a space
      ([a-zA-Z]{2,15}).?\s?  the next part must be an alphabetical string with 2-15 characters followed by a any digit (optionally) and/or space (optionally)
      (\w{0,5})$ the end of the line can have 0-5 letters
   */
@@ -269,36 +269,35 @@ function getPhotoCroppingValues(photo_cropping_object) {
 
   // 1. calculate threshold for the x space
   // we check if the coordinate starts on the left side of the image (the first half of the left side)
-  let x_left_threeshold = origWidth / 4
+  let x_left_threshold = origWidth / 4
   // we check if the coordinate starts on the right side of the image (the first half of the right side) and we reduce a margin of 5% to be flexible
-  let substract_percentage = 0.05
-  let x_right_threeshold =
-    origWidth / 2 - substract_percentage * (origWidth / 2)
-  // 2. calculate threeshold for the y space
+  let subtract_percentage = 0.05
+  let x_right_threshold = origWidth / 2 - subtract_percentage * (origWidth / 2)
+  // 2. calculate threshold for the y space
   // we check if the coordinate starts on the top side of the image (the first half of the top side)
-  let y_top_threeshold = oriHeight / 4
+  let y_top_threshold = oriHeight / 4
   // we check if the coordinate starts on the bottom side of the image (the first half of the bottom side) and we reduce a margin of 5% to be flexible
-  let y_bottom_threeshold = oriHeight / 2 - (5 / 100) * (oriHeight / 2)
+  let y_bottom_threshold = oriHeight / 2 - (5 / 100) * (oriHeight / 2)
 
   // 3. determine the css values for the cropping
-  // if the coordinate does not reach any of the threesholds, we set the value to center
+  // if the coordinate does not reach any of the thresholds, we set the value to center
   let x_value = 'center'
   // left threshold met
-  if (x <= x_left_threeshold) {
+  if (x <= x_left_threshold) {
     x_value = 'left'
   }
   // right threshold met
-  if (x >= x_right_threeshold) {
+  if (x >= x_right_threshold) {
     x_value = 'right'
   }
   // we apply the same logic for the y or vertical direction
   let y_value = 'center'
   // top threshold met
-  if (y <= y_top_threeshold) {
+  if (y <= y_top_threshold) {
     y_value = 'top'
   }
   // bottom threshold met
-  if (y >= y_bottom_threeshold) {
+  if (y >= y_bottom_threshold) {
     y_value = 'bottom'
   }
 
@@ -329,7 +328,7 @@ function getOfficialSocialMediaPages(identifiers) {
           type: 'twitter',
           url: 'https://twitter.com/' + identifier.identifier_value,
           icon: 'fa-brands fa-twitter',
-          color: '#1DA1F2' // offiial twitter color
+          color: '#1DA1F2' // official twitter color
         })
         break
 

--- a/src/components/DonateMoney.vue
+++ b/src/components/DonateMoney.vue
@@ -10,6 +10,7 @@
 
       <v-btn-toggle
         v-model="donationAmount"
+        class="d-flex flex-wrap justify-center"
         tile
         color="deep-purple accent-3"
         group
@@ -166,14 +167,15 @@ export default {
 
 <style scoped lang="less">
 .custom-donation-amount-textfield {
-  width: 150px;
+  margin-top: 1em;
+  min-width: 10em;
 }
 .message {
   background-color: #fff8e6;
   border-radius: 0.25em;
   border: 1px solid #e6a700;
   color: #4d3800;
-  margin-top: 2em;
+  // margin-top: 1em;
   padding: 0.25em;
 }
 </style>

--- a/src/components/DonateMoney.vue
+++ b/src/components/DonateMoney.vue
@@ -14,12 +14,63 @@
         color="deep-purple accent-3"
         group
       >
-        <v-btn elevation="2" raised :value="2"> 2 </v-btn>
+        <v-btn
+          elevation="2"
+          raised
+          :value="2"
+          @click="unsetCustomAmountSelection"
+        >
+          2
+        </v-btn>
 
-        <v-btn elevation="2" raised :value="20"> 20 </v-btn>
+        <v-btn
+          elevation="2"
+          raised
+          :value="20"
+          @click="unsetCustomAmountSelection"
+        >
+          20
+        </v-btn>
 
-        <v-btn elevation="2" :value="50"> 50 </v-btn>
+        <v-btn
+          elevation="2"
+          raised
+          :value="50"
+          @click="unsetCustomAmountSelection"
+        >
+          50
+        </v-btn>
+
+        <v-btn
+          elevation="2"
+          raised
+          :value="customDonationAmount"
+          @click="handleCustomAmountSelection"
+        >
+          Custom Amount
+        </v-btn>
       </v-btn-toggle>
+
+      <div class="d-flex justify-center flex-column align-center :width=100%">
+        <v-text-field
+          v-if="customAmountSelected"
+          v-model="customDonationAmount"
+          class="custom-donation-amount-textfield"
+          type="number"
+          :precision="2"
+          :step="0.01"
+          :max="10000"
+          :min="1.5"
+          label="Donation Amount"
+          :value="customDonationAmount"
+          @input="validateDonationAmount"
+          required
+        />
+      </div>
+
+      <p v-if="message !== ''" class="message">
+        {{ message }}
+      </p>
     </v-col>
     <div>
       <v-btn outlined color="primary" text @click="submit"> Submit </v-btn>
@@ -30,22 +81,76 @@
 <script lang="js">
 import axios from 'axios'
 export default {
-    name: 'DonateMoney',
-    props: [],
-    data () {
-      return {
-        donationAmount: 1.50
+  name: 'DonateMoney',
+  props: [],
+  data () {
+    return {
+      donationAmount: 2,
+      customAmountSelected: false,
+      customDonationAmount: undefined, // set min value to be 1.5
+      message: ''
+    }
+  },
+  computed: {
+  },
+  mounted () {
+  },
+  methods: {
+    unsetCustomAmountSelection() {
+      this.customAmountSelected = false;
+      this.message = "";
+    },
+    handleCustomAmountSelection() {
+      this.customAmountSelected = !this.customAmountSelected;
+      this.message = "";
+    },
+    validateDonationAmount(value = this.customDonationAmount) {
+      let isValid = true;
+      value = parseFloat(value); // outputs: number
+      value = value.toFixed(2); // outputs: string
+      value = parseFloat(value); // outputs: number
+      console.log(`🚀 -> file: DonateMoney.vue:112 -> validateDonationAmount -> value`, value, this.customAmountSelected);
+      // separating parameter assignment and parseFloat operation for consistent outcome on change
+
+      // if an existing donation amount button was chosen
+      if (!this.customAmountSelected) {
+        value = this.donationAmount;
+        return { value, isValid } // i.e. { 2 || 20 || 50, true }
+      }
+
+      if (value > 1.49 && value < 10000.01) {
+        this.message = "";
+        return { value, isValid }; // { 1.50, true }
+      }
+
+      if (isNaN(value)) { // undefined || NaN
+        this.message = "Please select or enter a valid amount.";
+      }
+      if (value < 1.5) {
+        this.message = "Please enter a donation amount higher than $1.50.";
+      }
+      if (value > 10000) {
+        this.message = "Amplify currently only accept donation amounts less than $10,000."
+      }
+
+      isValid = false;
+      return { value, isValid }; // i.e. { undefined, false }
+    },
+    submit() {
+      const { value, isValid } = this.validateDonationAmount();
+      // console.log(`the value: ${value} is ${isValid ? 'valid' : 'NOT valid'}`);
+
+      if (isValid) {
+        this.createCheckoutSession(value);
+        this.message = ""; // only refreshes message after input value becomes valid
+      } else {
+        this.message = "The donation amount is not valid."; // edge case?
+        return;
       }
     },
-    computed: {
-    },
-    mounted () {
-    },
-    methods: {
-      submit () {
-        axios.post('/api/checkout/create-checkout-session', {donationAmount: this.donationAmount})
+    createCheckoutSession (donationAmount) {
+      axios.post('/api/checkout/create-checkout-session', {donationAmount})
         .then((response) => {
-          console.log(response);
           // Dump state to local storage before redirect
           this.$store.dispatch('dumpStateToLocalStorage', response.data.sessionId)
           // Redirect to stripe
@@ -54,13 +159,21 @@ export default {
         .catch(function (error) {
           console.log(error)
         })
-      }
     }
+  }
 }
 </script>
 
 <style scoped lang="less">
 .custom-donation-amount-textfield {
   width: 150px;
+}
+.message {
+  background-color: #fff8e6;
+  border-radius: 0.25em;
+  border: 1px solid #e6a700;
+  color: #4d3800;
+  margin-top: 2em;
+  padding: 0.25em;
 }
 </style>

--- a/src/components/DonateMoney.vue
+++ b/src/components/DonateMoney.vue
@@ -110,7 +110,6 @@ export default {
       value = parseFloat(value); // outputs: number
       value = value.toFixed(2); // outputs: string
       value = parseFloat(value); // outputs: number
-      console.log(`🚀 -> file: DonateMoney.vue:112 -> validateDonationAmount -> value`, value, this.customAmountSelected);
       // separating parameter assignment and parseFloat operation for consistent outcome on change
 
       // if an existing donation amount button was chosen

--- a/src/components/DonateMoney.vue
+++ b/src/components/DonateMoney.vue
@@ -8,7 +8,12 @@
         representatives, from the comfort of your home or on the go.
       </p>
 
-      <v-btn-toggle v-model="donation" tile color="deep-purple accent-3" group>
+      <v-btn-toggle
+        v-model="donationAmount"
+        tile
+        color="deep-purple accent-3"
+        group
+      >
         <v-btn elevation="2" raised :value="2"> 2 </v-btn>
 
         <v-btn elevation="2" raised :value="20"> 20 </v-btn>
@@ -29,7 +34,7 @@ export default {
     props: [],
     data () {
       return {
-        donation: 1.50
+        donationAmount: 1.50
       }
     },
     computed: {
@@ -38,7 +43,7 @@ export default {
     },
     methods: {
       submit () {
-        axios.post('/api/checkout/create-checkout-session', {donationAmount: this.donation})
+        axios.post('/api/checkout/create-checkout-session', {donationAmount: this.donationAmount})
         .then((response) => {
           console.log(response);
           // Dump state to local storage before redirect
@@ -54,4 +59,8 @@ export default {
 }
 </script>
 
-<style scoped lang="less"></style>
+<style scoped lang="less">
+.custom-donation-amount-textfield {
+  width: 150px;
+}
+</style>

--- a/src/components/DonateMoney.vue
+++ b/src/components/DonateMoney.vue
@@ -64,6 +64,7 @@
           :min="1.5"
           label="Donation Amount"
           :value="customDonationAmount"
+          inputmode="numeric"
           @input="validateDonationAmount"
           required
         />


### PR DESCRIPTION
# Issue

**#407 Donation Parsing / Custom Donation Input:** 

Currently, Amplify only allows donations of $1, $2, $20, and $50 (and soon $1.50). It would be nice to allow users to make a custom donation, as well as make it more clear what the default donation is.

# Fix 

This PR primarily tackles step 1 / part 1 of 4 subtasks, which is to (1) update UI to accept custom donations and clearly indicate a default value, but paves the way for (3) that donations are correctly being sent to Stripe.

Here are some changes, assumptions, and consideration: 
- [x] added a "Custom Amount" `v-btn`
- [x] added a "Donation Amount" `v-text-input`
- [x] added corresponding input validation
  - [x] provides feedback message to user for 
    - No amount
    - Minimum amount ($1.50)
    - Maximum amount ($10,000)
  - [x] validated user input will always be a number with 2 decimal places
  - [x] if user tries to manually enter a number with 2+ decimal places, it'll be rounded up
  - [ ] todo: backend will only need to multiply by 100 for Stripe Checkout
- [x] applied consistent styles for all toggle buttons & text input
- [x] default value is $2, and user can input $1.5 as minimum value. So, we might be able to say the $1.50 button is solved together with this custom amount feature?
- [x] considered mobile responsiveness for different screen sizes
- [x] improved code readability

Enjoyed working with @coderlore & @Alex-is-Gonzalez on this!

Feedback is always welcome!