### PR TITLE
removal of bad example key for Stripe secret.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ AUTH0_AUDIENCE=your_Auth0_identifier_value
 AUTH0_DOMAIN=your_Auth0_domain
 
 # Stripe
-STRIPE_SECRET_KEY=sk_test_51IravfFqipIA40A3FOW6EzlXlJiXjL9V0FXKfb9n7cxh25Ww9QMA9aWwCzTSQscBOQFcB7s1TI6UCtW1JG83Hz1z000Sg2vSIr
+STRIPE_SECRET_KEY=
 
 # To run in single-campaign mode, set the following environment vars
 VUE_APP_CAMPAIGN_MODE = "single" # or "default" for normaal operation


### PR DESCRIPTION
**Issue:
Appears that Stripe secret key was committed accidentally

**Fix:
removing out of abundance of caution 