### PR TITLE
Modifications to the bootstrap script to properly run on OS X

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
 brew "nodenv"
-brew "postgresql"
+brew "postgresql@14"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,12 +2,13 @@
 
 set -e
 
+# If homebrew is not installed, install it
 command -v brew >/dev/null 2>&1 || {
   echo "==> Installing Homebrew..."
   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 }
 
-if [[ -z "${CODESPACES}" ]]; then
+if [[ "$OSTYPE" =~ ^linux ]] || [[ -n "${CODESPACES}" ]]; then
   echo "==> Adding Homebrew to the PATH..."
   echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/node/.profile
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -25,7 +26,7 @@ echo "==> Installing Node"
 nodenv install -s
 
 echo "==> Starting PostgreSQL service..."
-brew services restart postgres
+brew services restart postgresql@14
 
 echo "==> Installing Node dependencies..."
 npm install


### PR DESCRIPTION
Currently the logic in `setup/bootstrap.sh` causes the script to fail on OS X. This is because it currently is trying to use linuxbrew when it should not. This change adds some conditions to ensure the linuxbrew commands only run on Linux or in Github Codespaces.

I tested this against my fork using Codespaces and it seems to be working. 

Resolves #500