### PR TITLE
Remove unneeded library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@auth0/auth0-spa-js": "^1.22.5",
-        "@auth0/auth0-vue": "^2.1.0",
         "@babel/polyfill": "^7.4.4",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -93,52 +92,6 @@
         "fast-text-encoding": "^1.0.6",
         "promise-polyfill": "^8.2.3",
         "unfetch": "^4.2.0"
-      }
-    },
-    "node_modules/@auth0/auth0-vue": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-vue/-/auth0-vue-2.1.0.tgz",
-      "integrity": "sha512-PQdhLylJAR10ILnz5DSxGcvX8siOl1UGK/O6mYu7+gysHCBO0u0uDP8oxuL1roFuSSkxVGXgDzn6YbcwEctkaA==",
-      "dependencies": {
-        "@auth0/auth0-spa-js": "^2.0.4",
-        "vue": "^3.2.41"
-      },
-      "peerDependencies": {
-        "vue-router": "^4.0.12"
-      },
-      "peerDependenciesMeta": {
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@auth0/auth0-vue/node_modules/@auth0/auth0-spa-js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.4.tgz",
-      "integrity": "sha512-NgD6Fkm5Xnbned1VjhEW8irm1/Y8AWtdSLexgLXNwwBVgfnYicCVBu8w75m2t+4QljXkTcI7IXVEFhVmxMuxaA=="
-    },
-    "node_modules/@auth0/auth0-vue/node_modules/@vue/server-renderer": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.47.tgz",
-      "integrity": "sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.2.47",
-        "@vue/shared": "3.2.47"
-      },
-      "peerDependencies": {
-        "vue": "3.2.47"
-      }
-    },
-    "node_modules/@auth0/auth0-vue/node_modules/vue": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.47.tgz",
-      "integrity": "sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==",
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.47",
-        "@vue/compiler-sfc": "3.2.47",
-        "@vue/runtime-dom": "3.2.47",
-        "@vue/server-renderer": "3.2.47",
-        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -610,6 +563,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
       "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -4211,6 +4165,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
       "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/shared": "3.2.47",
@@ -4222,6 +4179,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
       "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.2.47",
         "@vue/shared": "3.2.47"
@@ -4231,6 +4191,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.47.tgz",
       "integrity": "sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.47",
@@ -4248,6 +4211,7 @@
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
       "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4258,6 +4222,8 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -4271,6 +4237,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.47.tgz",
       "integrity": "sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.47",
         "@vue/shared": "3.2.47"
@@ -4320,18 +4289,13 @@
         "webpack": ">=4.0.0"
       }
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.47.tgz",
-      "integrity": "sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==",
-      "dependencies": {
-        "@vue/shared": "3.2.47"
-      }
-    },
     "node_modules/@vue/reactivity-transform": {
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.47.tgz",
       "integrity": "sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.47",
@@ -4340,29 +4304,13 @@
         "magic-string": "^0.25.7"
       }
     },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.47.tgz",
-      "integrity": "sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==",
-      "dependencies": {
-        "@vue/reactivity": "3.2.47",
-        "@vue/shared": "3.2.47"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.47.tgz",
-      "integrity": "sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==",
-      "dependencies": {
-        "@vue/runtime-core": "3.2.47",
-        "@vue/shared": "3.2.47",
-        "csstype": "^2.6.8"
-      }
-    },
     "node_modules/@vue/shared": {
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
-      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ=="
+      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@vue/web-component-wrapper": {
       "version": "1.3.0",
@@ -7202,11 +7150,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-    },
     "node_modules/cyclist": {
       "version": "1.0.1",
       "dev": true,
@@ -8324,7 +8267,10 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -12344,6 +12290,9 @@
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
@@ -12757,6 +12706,9 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -13858,6 +13810,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -16008,6 +15961,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16017,6 +15971,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16051,7 +16008,10 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -19652,43 +19612,6 @@
         "unfetch": "^4.2.0"
       }
     },
-    "@auth0/auth0-vue": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-vue/-/auth0-vue-2.1.0.tgz",
-      "integrity": "sha512-PQdhLylJAR10ILnz5DSxGcvX8siOl1UGK/O6mYu7+gysHCBO0u0uDP8oxuL1roFuSSkxVGXgDzn6YbcwEctkaA==",
-      "requires": {
-        "@auth0/auth0-spa-js": "^2.0.4",
-        "vue": "^3.2.41"
-      },
-      "dependencies": {
-        "@auth0/auth0-spa-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.4.tgz",
-          "integrity": "sha512-NgD6Fkm5Xnbned1VjhEW8irm1/Y8AWtdSLexgLXNwwBVgfnYicCVBu8w75m2t+4QljXkTcI7IXVEFhVmxMuxaA=="
-        },
-        "@vue/server-renderer": {
-          "version": "3.2.47",
-          "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.47.tgz",
-          "integrity": "sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==",
-          "requires": {
-            "@vue/compiler-ssr": "3.2.47",
-            "@vue/shared": "3.2.47"
-          }
-        },
-        "vue": {
-          "version": "3.2.47",
-          "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.47.tgz",
-          "integrity": "sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==",
-          "requires": {
-            "@vue/compiler-dom": "3.2.47",
-            "@vue/compiler-sfc": "3.2.47",
-            "@vue/runtime-dom": "3.2.47",
-            "@vue/server-renderer": "3.2.47",
-            "@vue/shared": "3.2.47"
-          }
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "dev": true,
@@ -20023,7 +19946,8 @@
     "@babel/parser": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -22692,6 +22616,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
       "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/shared": "3.2.47",
@@ -22703,6 +22630,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
       "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@vue/compiler-core": "3.2.47",
         "@vue/shared": "3.2.47"
@@ -22712,6 +22642,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.47.tgz",
       "integrity": "sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.47",
@@ -22729,6 +22662,9 @@
           "version": "8.4.21",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
           "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "nanoid": "^3.3.4",
             "picocolors": "^1.0.0",
@@ -22741,6 +22677,9 @@
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.47.tgz",
       "integrity": "sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.2.47",
         "@vue/shared": "3.2.47"
@@ -22780,18 +22719,13 @@
       "dev": true,
       "requires": {}
     },
-    "@vue/reactivity": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.47.tgz",
-      "integrity": "sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==",
-      "requires": {
-        "@vue/shared": "3.2.47"
-      }
-    },
     "@vue/reactivity-transform": {
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.47.tgz",
       "integrity": "sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.47",
@@ -22800,29 +22734,13 @@
         "magic-string": "^0.25.7"
       }
     },
-    "@vue/runtime-core": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.47.tgz",
-      "integrity": "sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==",
-      "requires": {
-        "@vue/reactivity": "3.2.47",
-        "@vue/shared": "3.2.47"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.47.tgz",
-      "integrity": "sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==",
-      "requires": {
-        "@vue/runtime-core": "3.2.47",
-        "@vue/shared": "3.2.47",
-        "csstype": "^2.6.8"
-      }
-    },
     "@vue/shared": {
       "version": "3.2.47",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
-      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ=="
+      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@vue/web-component-wrapper": {
       "version": "1.3.0",
@@ -24907,11 +24825,6 @@
         }
       }
     },
-    "csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-    },
     "cyclist": {
       "version": "1.0.1",
       "dev": true
@@ -25697,7 +25610,10 @@
     "estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -28547,6 +28463,9 @@
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
@@ -28850,7 +28769,10 @@
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -29627,7 +29549,8 @@
       }
     },
     "picocolors": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -31188,12 +31111,16 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -31221,7 +31148,10 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "spawn-command": {
       "version": "0.0.2-1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.22.5",
-    "@auth0/auth0-vue": "^2.1.0",
     "@babel/polyfill": "^7.4.4",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",


### PR DESCRIPTION
In working with @beverand , we determined that auth0-vue library is for Vue version 3.

As @paramsiddharth informed @beverand , we're using version 2 and we already have auth0 installed and working based on what we see in [package.json line 44](https://github.com/ProgramEquity/amplify/blob/main/package.json#L44) and [main.js](https://github.com/ProgramEquity/amplify/blob/main/src/main.js#L33).

Let's remove this conflicting library.

The appropriate tutorial is https://developer.auth0.com/resources/guides/spa/vue/basic-authentication/v2-javascript.