### PR TITLE
created draft PR for GHA dependabot pr to slack

### DIFF
--- a/.github/workflows/dependabot-pr-to-slack.yml
+++ b/.github/workflows/dependabot-pr-to-slack.yml
@@ -1,0 +1,26 @@
+name: Notify team/reviewers of dependabot updates via Slack
+
+on: 
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  slackNotification:
+    name: Slack Notification
+    if: startsWith(github.head_ref, 'dependabot/') # This step only runs when PR has dependabot/ HEAD
+    runs-on: ubuntu-latest
+
+    steps:
+    # Latest version available at: https://github.com/actions/checkout/releases
+
+    - uses: actions/checkout@v2.5.0
+    - name: Slack Notification
+      # Latest version available at: https://github.com/kv109/action-ready-for-review/releases
+      uses: kv109/action-ready-for-review@0.2
+      env:
+        SLACK_CHANNEL: dependabot-notifications  # to be worked on
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }} # to be worked on
+
+# ref: https://www.teracloud.io/single-post/dependabot-get-slack-notifications-using-github-actions


### PR DESCRIPTION
# Description
This is a draft pull request for creating a GitHub Action workflow. The goal is to send Slack messages to maintainers / mentors when Dependabot creates pull requests (upon identifying a newer version of a dependency).

Currently, `/.github/dependabot.yml` is configured to open PRs when identifying updates for `npm` packages and `github-actions` packages.

Currently, `/.github/workflows/programequity_slack.yml` is configured to send messages ProgramEquity's Slack workspace - `devs` Channel - for nearly all activities (opened, edited, submitted issues / comments / PRs). The instruction to send message to the `devs` channel is likely in the Repo Secrets. 

We discussed about whether to use a manual list of maintainers / dev-leads (such as it is currently done in `/.github/mention-to-slack.yml` or to use a "maintainers" / "dev-leads" Channel in Slack, following the [Teratip article][Teratip] on **Dependabot: Get Slack notifications using GitHub Actions**, and it seemed that we were leaning towards using a Slack Channel instead of a yaml config file. The reasoning being it may be easier to add or remove maintainers to a Slack channel then updating the `.yml` file.

# Status
Under Development.

Will check in with dev-leads to see if we an review current `${{ secrets.SLACK_WEBHOOK_URL }}` if we want to continue using GHA `abeyuya/actions-mention-to-slack@v2`. I am curious to peek under the hood regardless. 

Or, will figure out how to configure things on Slack so that `dependabot-pr-to-slack.yml` can send messages to a Slack Channel such as possibly `dev-leads`, but that will need to be configured by @manishapriya94 as well.

# Resources
[Dependabot: Get Slack notifications using GitHub Actions](https://www.teracloud.io/single-post/dependabot-get-slack-notifications-using-github-actions)

[Teratip]: https://www.teracloud.io/single-post/dependabot-get-slack-notifications-using-github-actions