### PR TITLE
Create new v1 Campaign PUT Rest Endpoint

### DIFF
--- a/server/__tests__/integration/server/routes/api/v1/campaigns/campaign_put_endpoint.test.js
+++ b/server/__tests__/integration/server/routes/api/v1/campaigns/campaign_put_endpoint.test.js
@@ -1,8 +1,8 @@
 const request = require('supertest')
-const app = require('../../app')
-const Campaign = require('../../db/models/campaign')
+const app = require('../../../../../../../app')
+const Campaign = require('../../../../../../../db/models/campaign')
 
-jest.mock('../../db/models/campaign')
+jest.mock('../../../../../../../db/models/campaign')
 
 describe('PUT /api/v1/campaigns/:id', () => {
   it('should return 200 if successfully updated the campaign', async () => {

--- a/server/__tests__/unit/campaign_put_endpoint.test.js
+++ b/server/__tests__/unit/campaign_put_endpoint.test.js
@@ -1,19 +1,38 @@
 const request = require('supertest')
 const app = require('../../app')
+const Campaign = require('../../db/models/campaign');
+
+jest.mock('../../db/models/campaign');
+
 
 describe('PUT /api/v1/campaigns/:id', () => {
   it('should return 200 if successfully updated the campaign', async () => {
+      const campaignData = {
+        id: 5,
+        name: "Sogorea 'Te Land Trust",
+        organization: "Sogorea 'Te Land Trust",
+        page_url: "https://sogoreate-landtrust.org/",
+        cause: "Civic Rights",
+        type: "Grant"
+      };
+      // Mock patchAndFetchById to return a resolved promise
+      Campaign.query.mockReturnValue({
+        patchAndFetchById: jest.fn().mockResolvedValue(campaignData)
+      });
     const response = await request(app)
       .put('/api/v1/campaigns/5')
       .send({
-        campaign: {
-          type: 'Grant'
-        }
+        campaign: campaignData
       })
     expect(response.status).toBe(200)
+    expect(response.body.campaign).toEqual(campaignData);
   })
 
-  it('should return 404 if no campaign is found', async () => {
+  it('should return 400 if no campaign is found', async () => {
+    // Mock patchAndFetchById to return undefined
+    Campaign.query.mockReturnValue({
+      patchAndFetchById: jest.fn().mockResolvedValue(undefined)
+    });
     const response = await request(app)
       .put('/api/v1/campaigns/999999')
       .send({ campaign: { type: 'Accelerator' } })
@@ -23,6 +42,10 @@ describe('PUT /api/v1/campaigns/:id', () => {
   })
 
   it('should return 500 for invalid update', async () => {
+    // Mock patchAndFetchById to throw an error
+    Campaign.query.mockReturnValue({
+    patchAndFetchById: jest.fn().mockRejectedValue(new Error('Server error'))
+    });
     const response = await request(app)
       .put('/api/v1/campaigns/5')
       .send({
@@ -34,3 +57,4 @@ describe('PUT /api/v1/campaigns/:id', () => {
     expect(response.status).toBe(500)
   })
 })
+

--- a/server/__tests__/unit/campaign_put_endpoint.test.js
+++ b/server/__tests__/unit/campaign_put_endpoint.test.js
@@ -1,0 +1,36 @@
+const request = require('supertest')
+const app = require('../../app')
+
+describe('PUT /api/v1/campaigns/:id', () => {
+  it('should return 200 if successfully updated the campaign', async () => {
+    const response = await request(app)
+      .put('/api/v1/campaigns/5')
+      .send({
+        campaign: {
+          type: 'Grant'
+        }
+      })
+    expect(response.status).toBe(200)
+  })
+
+  it('should return 404 if no campaign is found', async () => {
+    const response = await request(app)
+      .put('/api/v1/campaigns/999999')
+      .send({ campaign: { type: 'Accelerator' } })
+
+    expect(response.status).toBe(404)
+    expect(response.body.msg).toBe('Campaign not found')
+  })
+
+  it('should return 500 for invalid update', async () => {
+    const response = await request(app)
+      .put('/api/v1/campaigns/5')
+      .send({
+        campaign: {
+          type: 'random'
+        }
+      })
+
+    expect(response.status).toBe(500)
+  })
+})

--- a/server/__tests__/unit/campaign_put_endpoint.test.js
+++ b/server/__tests__/unit/campaign_put_endpoint.test.js
@@ -1,38 +1,35 @@
 const request = require('supertest')
 const app = require('../../app')
-const Campaign = require('../../db/models/campaign');
+const Campaign = require('../../db/models/campaign')
 
-jest.mock('../../db/models/campaign');
-
+jest.mock('../../db/models/campaign')
 
 describe('PUT /api/v1/campaigns/:id', () => {
   it('should return 200 if successfully updated the campaign', async () => {
-      const campaignData = {
-        id: 5,
-        name: "Sogorea 'Te Land Trust",
-        organization: "Sogorea 'Te Land Trust",
-        page_url: "https://sogoreate-landtrust.org/",
-        cause: "Civic Rights",
-        type: "Grant"
-      };
-      // Mock patchAndFetchById to return a resolved promise
-      Campaign.query.mockReturnValue({
-        patchAndFetchById: jest.fn().mockResolvedValue(campaignData)
-      });
-    const response = await request(app)
-      .put('/api/v1/campaigns/5')
-      .send({
-        campaign: campaignData
-      })
+    const campaignData = {
+      id: 5,
+      name: "Sogorea 'Te Land Trust",
+      organization: "Sogorea 'Te Land Trust",
+      page_url: 'https://sogoreate-landtrust.org/',
+      cause: 'Civic Rights',
+      type: 'Grant'
+    }
+    // Mock patchAndFetchById to return a resolved promise
+    Campaign.query.mockReturnValue({
+      patchAndFetchById: jest.fn().mockResolvedValue(campaignData)
+    })
+    const response = await request(app).put('/api/v1/campaigns/5').send({
+      campaign: campaignData
+    })
     expect(response.status).toBe(200)
-    expect(response.body.campaign).toEqual(campaignData);
+    expect(response.body.campaign).toEqual(campaignData)
   })
 
   it('should return 400 if no campaign is found', async () => {
     // Mock patchAndFetchById to return undefined
     Campaign.query.mockReturnValue({
       patchAndFetchById: jest.fn().mockResolvedValue(undefined)
-    });
+    })
     const response = await request(app)
       .put('/api/v1/campaigns/999999')
       .send({ campaign: { type: 'Accelerator' } })
@@ -44,8 +41,8 @@ describe('PUT /api/v1/campaigns/:id', () => {
   it('should return 500 for invalid update', async () => {
     // Mock patchAndFetchById to throw an error
     Campaign.query.mockReturnValue({
-    patchAndFetchById: jest.fn().mockRejectedValue(new Error('Server error'))
-    });
+      patchAndFetchById: jest.fn().mockRejectedValue(new Error('Server error'))
+    })
     const response = await request(app)
       .put('/api/v1/campaigns/5')
       .send({
@@ -57,4 +54,3 @@ describe('PUT /api/v1/campaigns/:id', () => {
     expect(response.status).toBe(500)
   })
 })
-

--- a/server/api.js
+++ b/server/api.js
@@ -13,6 +13,9 @@ const checkout = require('./routes/api/checkout')
 const twilio = require('./routes/api/twilio')
 const eventLogger = require('./routes/api/event_logger')
 
+// import the whole collection of v1 routes
+const v1Router = require('./routes/api/v1/v1.js')
+
 // Created a nested router
 const apiRouter = express.Router()
 
@@ -35,5 +38,8 @@ apiRouter.use('/lob', lob)
 apiRouter.use('/checkout', checkout)
 apiRouter.use('/twilio', twilio)
 apiRouter.use('/event_logger', eventLogger)
+
+// Create the /v1 portion of the url.
+apiRouter.use('/v1', v1Router)
 
 module.exports = apiRouter

--- a/server/db/models/campaign.js
+++ b/server/db/models/campaign.js
@@ -29,21 +29,6 @@ class Campaign extends BaseModel {
       }
     }
   }
-
-  // This object defines the relations to other models.
-  static get relationMappings() {
-    const LetterVersion = require('./letter-version')
-    return {
-      LetterVersions: {
-        relation: BaseModel.HasManyRelation,
-        modelClass: LetterVersion,
-        join: {
-          from: 'campaigns.id',
-          to: 'letter_versions.campaign_id'
-        }
-      }
-    }
-  }
 }
 
 module.exports = Campaign

--- a/server/routes/api/v1/campaigns/index.js
+++ b/server/routes/api/v1/campaigns/index.js
@@ -36,4 +36,27 @@ router.get('/', async (req, res) => {
   }
 })
 
+// PUT request to update a campaign
+router.put('/:id', async (req, res) => {
+  const campaignId = req.params.id
+
+  if (!campaignId) return res.status(404).end()
+
+  try {
+    const updatedCampaign = await Campaign.query().patchAndFetchById(
+      campaignId,
+      req.body.campaign
+    )
+
+    if (!updatedCampaign)
+      return res.status(404).json({ msg: 'Campaign not found' }).end()
+
+    return res.status(200).json({ campaign: updatedCampaign }).end()
+  } catch (error) {
+    console.error(error.message)
+
+    return res.status(500).json({ msg: error.message }).end()
+  }
+})
+
 module.exports = router

--- a/server/routes/api/v1/campaigns/index.js
+++ b/server/routes/api/v1/campaigns/index.js
@@ -47,7 +47,6 @@ router.put('/:id', async (req, res) => {
       campaignId,
       req.body.campaign
     )
-
     if (!updatedCampaign)
       return res.status(404).json({ msg: 'Campaign not found' }).end()
 

--- a/server/routes/api/v1/campaigns/index.js
+++ b/server/routes/api/v1/campaigns/index.js
@@ -1,0 +1,39 @@
+const express = require('express')
+const Campaign = require('../../../../db/models/campaign')
+
+const router = express.Router()
+
+// Middleware for authentication can get passed into v1 route aggregator
+// so we will assume here that someone requesting these endpoints has already
+// been authorized.
+router.get('/:id', async (req, res) => {
+  const campaignId = req.params.id
+
+  if (!campaignId) return res.status(404).end()
+
+  try {
+    const campaign = await Campaign.query().findById(campaignId)
+
+    if (!campaign) return res.status(404).end()
+
+    return res.status(200).json({ campaign }).end()
+  } catch (error) {
+    console.error(error.message)
+
+    return res.status(500).json({ msg: 'There was a server error.' }).end()
+  }
+})
+
+router.get('/', async (req, res) => {
+  try {
+    const campaigns = await Campaign.query()
+
+    return res.status(200).json({ campaigns }).end()
+  } catch (error) {
+    console.error(error.message)
+
+    return res.status(500).json({ msg: 'There was a server error.' }).end()
+  }
+})
+
+module.exports = router

--- a/server/routes/api/v1/campaigns/index.js
+++ b/server/routes/api/v1/campaigns/index.js
@@ -3,39 +3,6 @@ const Campaign = require('../../../../db/models/campaign')
 
 const router = express.Router()
 
-// Middleware for authentication can get passed into v1 route aggregator
-// so we will assume here that someone requesting these endpoints has already
-// been authorized.
-router.get('/:id', async (req, res) => {
-  const campaignId = req.params.id
-
-  if (!campaignId) return res.status(404).end()
-
-  try {
-    const campaign = await Campaign.query().findById(campaignId)
-
-    if (!campaign) return res.status(404).end()
-
-    return res.status(200).json({ campaign }).end()
-  } catch (error) {
-    console.error(error.message)
-
-    return res.status(500).json({ msg: 'There was a server error.' }).end()
-  }
-})
-
-router.get('/', async (req, res) => {
-  try {
-    const campaigns = await Campaign.query()
-
-    return res.status(200).json({ campaigns }).end()
-  } catch (error) {
-    console.error(error.message)
-
-    return res.status(500).json({ msg: 'There was a server error.' }).end()
-  }
-})
-
 // PUT request to update a campaign
 router.put('/:id', async (req, res) => {
   const campaignId = req.params.id

--- a/server/routes/api/v1/v1.js
+++ b/server/routes/api/v1/v1.js
@@ -1,0 +1,9 @@
+const express = require('express')
+const campaigns = require('./campaigns') // If the routes file is named index.js, we can omit it when we do the import instead of writing './campaigns/index'.
+
+const v1Router = express.Router()
+
+// Create the final piece of the url /campaigns
+v1Router.use('/campaigns', campaigns)
+
+module.exports = v1Router


### PR DESCRIPTION
## Description
Create new Rest endpoint for **PUT** `/v1/campaigns/:id`; Updates the specified campaign when given a JSON payload of modified fields

## Acceptance Criteria
- [x] The PUT endpoint should work properly to update a specific campaign when given a JSON payload of modified fields
- [x] Testing script work as expected - all 3 tests passed

## Related Issue
#615 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria
### Jest Testing
- From your terminal, pull down this branch with `git pull origin 615-api-create-campaign-put-endpoint-Shangguan` and check that branch out with `git checkout 615-api-create-campaign-put-endpoint-Shangguan`
- Run `npm test -- --testPathPattern=campaign_put_endpoint.test.js` in terminal to run the test script

Expect to see all 3 test cases pass: 
![test case pass](https://github.com/ProgramEquity/amplify/assets/24996005/ca42af50-b0e2-42a5-b309-bd48f768932e)


### Manual Testing in Postman
- Run `npm run dev` to launch the app
**Scenario 1**: Successfully update a campaign
In Postman, first GET `http://localhost:8080/api/v1/campaigns/5`
![original campaign 5 data](https://github.com/ProgramEquity/amplify/assets/24996005/6e883f09-3914-482a-b18e-236343289345)
Create a new PUT request, and input updated campaign JSON under "Body", expect to see a status 200 with the updated campaign as returned result
![success put request](https://github.com/ProgramEquity/amplify/assets/24996005/9544126c-205a-4761-aa03-ef2d1414acba)

**Scenario 2**: The Campaign URL is incorrect
In Postman, PUT `http://localhost:8080/api/v1/campaigns/10` as an example, expect to see a `404 not found` error
![campaign not found](https://github.com/ProgramEquity/amplify/assets/24996005/4316e57b-3b80-48d0-9346-7273a9140f3a)

**Scenario 3**: Enter invalid input
In Postman, PUT `{
    "campaign": {
        "type": "Random"
    }
}` and expect to see a 500 error
![Screen Shot 2023-11-05 at 8 45 38 PM](https://github.com/ProgramEquity/amplify/assets/24996005/8de4b3c0-97d4-42f4-83a2-7834466994ef)