### PR TITLE
Add mock-representatives route to the API router, add tests & middleware

### DIFF
--- a/server/__tests__/integration/ciceroMockApi.test.js
+++ b/server/__tests__/integration/ciceroMockApi.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest')
+const express = require('express')
+const ciceroMockApi = require('../../routes/api/ciceroMockApi')
+
+const app = express()
+app.use('/mock-representatives', ciceroMockApi)
+
+describe('Test /mock-representatives route', () => {
+  test('It should respond with a 200 status and an array of representatives', async () => {
+    const response = await request(app).get('/mock-representatives/1003')
+    expect(response.statusCode).toBe(200)
+    expect(Array.isArray(response.body)).toBeTruthy()
+    expect(response.body.length).toBeGreaterThan(0)
+  })
+
+  test('Each representative should have an id property', async () => {
+    const response = await request(app).get('/mock-representatives/1003')
+    const representative = response.body[0]
+    expect(representative).toHaveProperty('id')
+  })
+
+  test('Each representative should have a name property', async () => {
+    const response = await request(app).get('/mock-representatives/1003')
+    const representative = response.body[0]
+    expect(representative).toHaveProperty('name')
+  })
+
+  test('Each representative should have a title property', async () => {
+    const response = await request(app).get('/mock-representatives/1003')
+    const representative = response.body[0]
+    expect(representative).toHaveProperty('title')
+  })
+})
+
+describe('Test /mock-representatives route error handling', () => {
+  test('It should respond with a 404 status for bad requests', async () => {
+    // Simulate a bad request by omitting required parameters
+    const response = await request(app).get('/mock-representatives')
+
+    // Expect a 404 status code in response
+    expect(response.statusCode).toBe(404)
+  })
+})

--- a/server/api.js
+++ b/server/api.js
@@ -13,6 +13,8 @@ const checkout = require('./routes/api/checkout')
 const twilio = require('./routes/api/twilio')
 const eventLogger = require('./routes/api/event_logger')
 
+const ciceroMockApi = require('./routes/api/ciceroMockApi')
+
 // import the whole collection of v1 routes
 const v1Router = require('./routes/api/v1/v1.js')
 
@@ -38,7 +40,7 @@ apiRouter.use('/lob', lob)
 apiRouter.use('/checkout', checkout)
 apiRouter.use('/twilio', twilio)
 apiRouter.use('/event_logger', eventLogger)
-
+apiRouter.use('/mock-representatives', ciceroMockApi)
 // Create the /v1 portion of the url.
 apiRouter.use('/v1', v1Router)
 

--- a/server/app.js
+++ b/server/app.js
@@ -9,8 +9,16 @@ const app = express()
 // see https://expressjs.com/en/guide/behind-proxies.html
 app.set('trust proxy', true)
 
+const representativeTestMidlleware = (req, res, next) => {
+  if (req.url.includes('/representatives') && process.env.NODE_ENV === 'test') {
+    // Redirect to the test endpoint
+    req.url = '/mock-representatives/94041'
+  }
+  next()
+}
+
 // Load the API router
-app.use('/api', apiRouter)
+app.use('/api', representativeTestMidlleware, apiRouter)
 
 // Fix for hash URLs in Vue
 // IMPORTANT: MUST be added before the `express.static` middleware for the `dist/` directory

--- a/server/routes/api/ciceroMockApi.js
+++ b/server/routes/api/ciceroMockApi.js
@@ -1,0 +1,94 @@
+const express = require('express')
+const router = express.Router()
+
+router.get('/:searchText', (req, res) => {
+  const representatives = [
+    {
+      id: 343935,
+      name: 'Lloyd Austin III',
+      title: 'Secretary of Defense',
+      address_line1: 'U.S. Department of Defense',
+      address_line2: '1000 Defense Pentagon',
+      address_city: 'Washington',
+      address_state: 'DC',
+      address_zip: '20301-1000',
+      address_country: 'US',
+      email: 'Not Made Public',
+      contactPage:
+        'https://www.defense.gov/our-story/meet-the-team/secretary-of-defense/',
+      photoUrl:
+        'https://media.defense.gov/2021/Jan/29/2002592436/825/780/0/210123-A-CN110-0001.JPG',
+      socialMediaPages: [
+        {
+          type: 'facebook',
+          url: 'https://facebook.com/DeptofDefense',
+          icon: 'fa-brands fa-facebook-f',
+          color: '#4267B2'
+        },
+        {
+          type: 'instagram',
+          url: 'https://instagram.com/austin_lloy',
+          icon: 'fa-brands fa-instagram',
+          color: '#C13584'
+        },
+        {
+          type: 'twitter',
+          url: 'https://twitter.com/SecDef',
+          icon: 'fa-brands fa-twitter',
+          color: '#1DA1F2'
+        },
+        {
+          type: 'twitter',
+          url: 'https://twitter.com/DeptofDefense',
+          icon: 'fa-brands fa-twitter',
+          color: '#1DA1F2'
+        }
+      ],
+      photoCroppingCSS: 'center center'
+    },
+    {
+      id: 343936,
+      name: 'John Doe',
+      title: 'Secretary of State',
+      address_line1: 'U.S. Department of State',
+      address_line2: '2201 C St NW',
+      address_city: 'Washington',
+      address_state: 'DC',
+      address_zip: '20520',
+      address_country: 'US',
+      email: 'Not Made Public',
+      contactPage: 'https://www.state.gov/secretary/',
+      photoUrl: 'https://example.com/photo.jpg',
+      socialMediaPages: [
+        {
+          type: 'facebook',
+          url: 'https://facebook.com/StateDept',
+          icon: 'fa-brands fa-facebook-f',
+          color: '#4267B2'
+        },
+        {
+          type: 'instagram',
+          url: 'https://instagram.com/StateDept',
+          icon: 'fa-brands fa-instagram',
+          color: '#C13584'
+        },
+        {
+          type: 'twitter',
+          url: 'https://twitter.com/SecState',
+          icon: 'fa-brands fa-twitter',
+          color: '#1DA1F2'
+        },
+        {
+          type: 'twitter',
+          url: 'https://twitter.com/StateDept',
+          icon: 'fa-brands fa-twitter',
+          color: '#1DA1F2'
+        }
+      ],
+      photoCroppingCSS: 'center center'
+    }
+  ]
+  res.json(representatives)
+})
+
+module.exports = router


### PR DESCRIPTION
Created a mock endpoint for Cicero API. Issue #509. Add 2 files to the project and modify 2 more:
1) In ciceroMockApi.js  file I created GET endpoint that now returns a selection of mock representatives in JSON format. 
2) In ciceroMockApi.test.js file I created comprehensive set of integration tests for the new route mock-representatives. These tests cover scenarios such as successful API calls and error-handling cases. 
3) Add route mock-representatives to Routes in api.js file. 
4) To simplify front-end development, I have implemented a middleware function in the app.js file.
This middleware intercepts the representatives call and redirects it to the newly created test endpoint when NODE_ENV environment variable is set to 'test'.

Initially, the issue suggested creating a POST request, but in the comment, I found information that GET is more suitable for this purpose. 