### PR TITLE
Linter action

### DIFF
--- a/.github/workflows/emojiPR.yml
+++ b/.github/workflows/emojiPR.yml
@@ -14,7 +14,12 @@ jobs:
     # This step checks out a copy of your repository and see if any changes have been made
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
+      #Pre step to install the node specified under .node-version file
+      - name: Setup node.js 16.x, 180x, 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
       # Step 2: Run PR emote generator.
       # This custom action is used to generate emotes for pull requests.
       # It's referencing to the main branch of an action that I created based off of the original PR Emote Generator action created by @rcmtcristian.

--- a/.github/workflows/linter_action.yml
+++ b/.github/workflows/linter_action.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node.js 16.x, 180x, 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16, 18, 20
+          node-version-file: '.node-version'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/linter_action.yml
+++ b/.github/workflows/linter_action.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4.1.1
 
-      - name: Setup node.js 16.x, 180x, 20.x
+      - name: Setup node.js for version 16.x, 18x, 20.x and specify it under .node-version file
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/linter_action.yml
+++ b/.github/workflows/linter_action.yml
@@ -1,0 +1,28 @@
+name: Lint code
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup node.js 16.x, 180x, 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16, 18, 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint -- --fix

--- a/.github/workflows/linter_action.yml
+++ b/.github/workflows/linter_action.yml
@@ -1,4 +1,4 @@
-name: Lint code
+name: Linting on Pull Request
 
 on:
   workflow_dispatch:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Run linter
         uses: cschleiden/actions-linter@caffd707beda4fc6083926a3dff48444bc7c24aa
         with:
-          # ".github/workflows/scorecards-analysis.yml" is an exception as `on: branch_protection_rule` is not recognized yet
-          workflows: '[".github/workflows/*.yml", ".github/workflows/*.yaml", "!.github/workflows/scorecards-analysis.yml"]'
+          # delete ".github/workflows/scorecards-analysis.yml" is an exception as `on: branch_protection_rule` is not recognized yet
+          workflows: '[".github/workflows/*.yml", ".github/workflows/*.yaml"]'


### PR DESCRIPTION
Created another linter action to run against node 16, 18, and 20, as long as the version is specified under .node-version file.
The linter action should lint on the pull request open and push.
Additionally, delete the scorecard-analysis file from workflow-lint, which might cause the action to fail at the moment